### PR TITLE
Add error handling for heading level 4+

### DIFF
--- a/src/sphinx_notion/__init__.py
+++ b/src/sphinx_notion/__init__.py
@@ -518,7 +518,8 @@ class NotionTranslator(NodeVisitor):
         if section_level > max_heading_level:
             error_msg = (
                 f"Notion only supports heading levels 1-{max_heading_level}, "
-                f"but found heading level {section_level}. "
+                f"but found heading level {section_level} on line "
+                f"{node.line}. "
                 f"Please restructure your document to use only heading levels "
                 f"1-{max_heading_level}."
             )

--- a/src/sphinx_notion/__init__.py
+++ b/src/sphinx_notion/__init__.py
@@ -518,10 +518,7 @@ class NotionTranslator(NodeVisitor):
         if section_level > max_heading_level:
             error_msg = (
                 f"Notion only supports heading levels 1-{max_heading_level}, "
-                f"but found heading level {section_level} on line "
-                f"{node.line}. "
-                f"Please restructure your document to use only heading levels "
-                f"1-{max_heading_level}."
+                f"but found heading level {section_level} on line {node.line}."
             )
             raise ValueError(error_msg)
 

--- a/src/sphinx_notion/__init__.py
+++ b/src/sphinx_notion/__init__.py
@@ -514,6 +514,16 @@ class NotionTranslator(NodeVisitor):
         """
         rich_text = _create_rich_text_from_children(node=node)
 
+        max_heading_level = 3
+        if section_level > max_heading_level:
+            error_msg = (
+                f"Notion only supports heading levels 1-{max_heading_level}, "
+                f"but found heading level {section_level}. "
+                f"Please restructure your document to use only heading levels "
+                f"1-{max_heading_level}."
+            )
+            raise ValueError(error_msg)
+
         heading_levels: dict[int, type[UnoHeading[Any]]] = {
             1: UnoHeading1,
             2: UnoHeading2,

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1424,6 +1424,6 @@ def test_heading_level_4_error(
 
     with pytest.raises(
         expected_exception=ValueError,
-        match=r"heading level 4",
+        match=r"heading level 4 on line \d+\.",
     ):
         app.build()

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1409,8 +1409,7 @@ def test_heading_level_4_error(
 
     expected_message = (
         "Notion only supports heading levels 1-3, but found heading level 4 "
-        "on line 11. "
-        "Please restructure your document to use only heading levels 1-3."
+        "on line 11."
     )
     with pytest.raises(
         expected_exception=ValueError,

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1381,3 +1381,49 @@ def test_literalinclude_with_caption(
         tmp_path=tmp_path,
         conf_py_content=conf_py_content,
     )
+
+
+def test_heading_level_4_error(
+    *,
+    make_app: Callable[..., SphinxTestApp],
+    tmp_path: Path,
+) -> None:
+    """
+    Heading level 4+ raises a clear error message.
+    """
+    rst_content = """
+        Main Title
+        ==========
+
+        Section Title
+        -------------
+
+        Subsection Title
+        ~~~~~~~~~~~~~~~~
+
+        Sub-subsection Title
+        ^^^^^^^^^^^^^^^^^^^^
+
+        Content under sub-subsection.
+    """
+
+    srcdir = tmp_path / "src"
+    srcdir.mkdir()
+
+    (srcdir / "conf.py").write_text(data="")
+
+    cleaned_content = textwrap.dedent(text=rst_content).strip()
+    (srcdir / "index.rst").write_text(data=cleaned_content)
+
+    app = make_app(
+        srcdir=srcdir,
+        builddir=tmp_path / "build",
+        buildername="notion",
+        confoverrides={"extensions": ["sphinx_notion"]},
+    )
+
+    with pytest.raises(
+        expected_exception=ValueError,
+        match=r"heading level 4",
+    ):
+        app.build()

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1422,8 +1422,13 @@ def test_heading_level_4_error(
         confoverrides={"extensions": ["sphinx_notion"]},
     )
 
+    expected_message = (
+        "Notion only supports heading levels 1-3, but found heading level 4 "
+        "on line 11. "
+        "Please restructure your document to use only heading levels 1-3."
+    )
     with pytest.raises(
         expected_exception=ValueError,
-        match=r"heading level 4 on line \d+\.",
+        match=expected_message,
     ):
         app.build()

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1407,21 +1407,6 @@ def test_heading_level_4_error(
         Content under sub-subsection.
     """
 
-    srcdir = tmp_path / "src"
-    srcdir.mkdir()
-
-    (srcdir / "conf.py").write_text(data="")
-
-    cleaned_content = textwrap.dedent(text=rst_content).strip()
-    (srcdir / "index.rst").write_text(data=cleaned_content)
-
-    app = make_app(
-        srcdir=srcdir,
-        builddir=tmp_path / "build",
-        buildername="notion",
-        confoverrides={"extensions": ["sphinx_notion"]},
-    )
-
     expected_message = (
         "Notion only supports heading levels 1-3, but found heading level 4 "
         "on line 11. "
@@ -1431,4 +1416,9 @@ def test_heading_level_4_error(
         expected_exception=ValueError,
         match=expected_message,
     ):
-        app.build()
+        _assert_rst_converts_to_notion_objects(
+            rst_content=rst_content,
+            expected_objects=[],
+            make_app=make_app,
+            tmp_path=tmp_path,
+        )


### PR DESCRIPTION
This PR implements error handling for heading levels 4+ as requested in issue #157.

## Changes

- Add validation in \`NotionTranslator\` to check for heading levels > 3
- Raise \`ValueError\` with clear message when heading level 4+ is encountered  
- Add integration test to verify error handling works correctly

## Testing

- All existing tests pass
- New integration test verifies the error is raised correctly
- Type checking passes

## Error Message

When a user tries to use heading level 4+, they will now see:
\`\`\`
ValueError: Notion only supports heading levels 1-3, but found heading level 4. Please restructure your document to use only heading levels 1-3.
\`\`\`

Fixes #157