### PR TITLE
Add support for numbered lists

### DIFF
--- a/sample/index.rst
+++ b/sample/index.rst
@@ -158,6 +158,25 @@ Some key features:
 * Supports images with URLs
 * Supports videos with URLs and local files
 
+Numbered Lists
+~~~~~~~~~~~~~~
+
+The builder now supports numbered lists:
+
+1. First numbered item
+2. Second numbered item with **bold text**
+3. Third numbered item with nested content
+
+   1. First nested numbered item
+   2. Second nested numbered item
+
+      1. Deeply nested numbered item
+      2. Another deeply nested item
+
+   3. Back to second level
+
+4. Fourth top-level item
+
 Heading 2 with *italic*
 -----------------------
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1156,7 +1156,6 @@ def test_nested_numbered_list(
         expected_objects=expected_objects,
         make_app=make_app,
         tmp_path=tmp_path,
-        extensions=("sphinx_notion", "sphinx_toolbox.collapse"),
     )
 
 


### PR DESCRIPTION
- Add NumberedItem import from ultimate_notion.blocks
- Implement _process_numbered_list_item_recursively method for handling nested numbered lists
- Add visit_enumerated_list method to handle enumerated_list nodes
- Add _process_node_to_blocks handler for enumerated_list nodes
- Add numbered_list_item to _reconstruct_nested_structure function
- Add comprehensive tests for flat, formatted, and nested numbered lists
- Add numbered list examples to sample documentation

Fixes #177