### PR TITLE
Simplify test helper to remove need for type hints on users

### DIFF
--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -6,7 +6,7 @@ import base64
 import json
 import re
 import textwrap
-from collections.abc import Callable, Collection
+from collections.abc import Callable, Collection, Sequence
 from pathlib import Path
 from typing import Any
 from uuid import UUID
@@ -79,7 +79,7 @@ def _details_from_block(
 def _assert_rst_converts_to_notion_objects(
     *,
     rst_content: str,
-    expected_objects: list[Block],
+    expected_blocks: Sequence[Block],
     make_app: Callable[..., SphinxTestApp],
     tmp_path: Path,
     extensions: tuple[str, ...] = ("sphinx_notion",),
@@ -124,7 +124,7 @@ def _assert_rst_converts_to_notion_objects(
 
     expected_json: list[dict[str, Any]] = [
         _details_from_block(block=expected_object)
-        for expected_object in expected_objects
+        for expected_object in expected_blocks
     ]
 
     assert generated_json == expected_json
@@ -143,13 +143,13 @@ def test_single_paragraph(
         This is a simple paragraph for testing.
     """
 
-    expected_objects: list[Block] = [
+    expected_blocks = [
         UnoParagraph(text=text(text="This is a simple paragraph for testing."))
     ]
 
     _assert_rst_converts_to_notion_objects(
         rst_content=rst_content,
-        expected_objects=expected_objects,
+        expected_blocks=expected_blocks,
         make_app=make_app,
         tmp_path=tmp_path,
     )
@@ -171,13 +171,13 @@ def test_notion_link_to_page(
 
     page_ref = PageRef(page_id=UUID(hex=test_page_id))
     obj_link_to_page = ObjLinkToPage(link_to_page=page_ref)
-    expected_objects: list[Block] = [
+    expected_blocks = [
         UnoLinkToPage.wrap_obj_ref(obj_link_to_page),
     ]
 
     _assert_rst_converts_to_notion_objects(
         rst_content=rst_content,
-        expected_objects=expected_objects,
+        expected_blocks=expected_blocks,
         make_app=make_app,
         tmp_path=tmp_path,
     )
@@ -203,7 +203,7 @@ def test_notion_link_to_page_with_content_around(
 
     page_ref = PageRef(page_id=UUID(hex=test_page_id))
     obj_link_to_page = ObjLinkToPage(link_to_page=page_ref)
-    expected_objects: list[Block] = [
+    expected_blocks = [
         UnoParagraph(text=text(text="This is a paragraph before.")),
         UnoLinkToPage.wrap_obj_ref(obj_link_to_page),
         UnoParagraph(text=text(text="This is a paragraph after.")),
@@ -211,7 +211,7 @@ def test_notion_link_to_page_with_content_around(
 
     _assert_rst_converts_to_notion_objects(
         rst_content=rst_content,
-        expected_objects=expected_objects,
+        expected_blocks=expected_blocks,
         make_app=make_app,
         tmp_path=tmp_path,
     )
@@ -262,7 +262,7 @@ def test_multiple_paragraphs(
         Third paragraph to test multiple blocks.
     """
 
-    expected_objects: list[Block] = [
+    expected_blocks = [
         UnoParagraph(text=text(text="First paragraph with some text.")),
         UnoParagraph(
             text=text(text="Second paragraph with different content.")
@@ -274,7 +274,7 @@ def test_multiple_paragraphs(
 
     _assert_rst_converts_to_notion_objects(
         rst_content=rst_content,
-        expected_objects=expected_objects,
+        expected_blocks=expected_blocks,
         make_app=make_app,
         tmp_path=tmp_path,
     )
@@ -312,11 +312,11 @@ def test_inline_formatting(
 
     expected_paragraph = UnoParagraph(text=combined_text)
 
-    expected_objects: list[Block] = [expected_paragraph]
+    expected_blocks = [expected_paragraph]
 
     _assert_rst_converts_to_notion_objects(
         rst_content=rst_content,
-        expected_objects=expected_objects,
+        expected_blocks=expected_blocks,
         make_app=make_app,
         tmp_path=tmp_path,
     )
@@ -335,13 +335,13 @@ def test_single_heading(
         ==========
     """
 
-    expected_objects: list[Block] = [
+    expected_blocks = [
         UnoHeading1(text=text(text="Main Title")),
     ]
 
     _assert_rst_converts_to_notion_objects(
         rst_content=rst_content,
-        expected_objects=expected_objects,
+        expected_blocks=expected_blocks,
         make_app=make_app,
         tmp_path=tmp_path,
     )
@@ -372,7 +372,7 @@ def test_multiple_heading_levels(
         Content under subsection.
     """
 
-    expected_objects: list[Block] = [
+    expected_blocks = [
         UnoHeading1(text=text(text="Main Title")),
         UnoParagraph(text=text(text="Content under main title.")),
         UnoHeading2(text=text(text="Section Title")),
@@ -383,7 +383,7 @@ def test_multiple_heading_levels(
 
     _assert_rst_converts_to_notion_objects(
         rst_content=rst_content,
-        expected_objects=expected_objects,
+        expected_blocks=expected_blocks,
         make_app=make_app,
         tmp_path=tmp_path,
     )
@@ -411,13 +411,13 @@ def test_heading_with_formatting(
 
     expected_heading = UnoHeading1(text=combined_text)
 
-    expected_objects: list[Block] = [
+    expected_blocks = [
         expected_heading,
     ]
 
     _assert_rst_converts_to_notion_objects(
         rst_content=rst_content,
-        expected_objects=expected_objects,
+        expected_blocks=expected_blocks,
         make_app=make_app,
         tmp_path=tmp_path,
     )
@@ -443,11 +443,11 @@ def test_simple_link(
 
     expected_paragraph = UnoParagraph(text=combined_text)
 
-    expected_objects: list[Block] = [expected_paragraph]
+    expected_blocks = [expected_paragraph]
 
     _assert_rst_converts_to_notion_objects(
         rst_content=rst_content,
-        expected_objects=expected_objects,
+        expected_blocks=expected_blocks,
         make_app=make_app,
         tmp_path=tmp_path,
     )
@@ -481,11 +481,11 @@ def test_multiple_links(
     )
 
     expected_paragraph = UnoParagraph(text=combined_text)
-    expected_objects: list[Block] = [expected_paragraph]
+    expected_blocks = [expected_paragraph]
 
     _assert_rst_converts_to_notion_objects(
         rst_content=rst_content,
-        expected_objects=expected_objects,
+        expected_blocks=expected_blocks,
         make_app=make_app,
         tmp_path=tmp_path,
     )
@@ -511,13 +511,13 @@ def test_link_in_heading(
 
     expected_heading = UnoHeading1(text=combined_text)
 
-    expected_objects: list[Block] = [
+    expected_blocks = [
         expected_heading,
     ]
 
     _assert_rst_converts_to_notion_objects(
         rst_content=rst_content,
-        expected_objects=expected_objects,
+        expected_blocks=expected_blocks,
         make_app=make_app,
         tmp_path=tmp_path,
     )
@@ -555,11 +555,11 @@ def test_mixed_formatting_with_links(
 
     expected_paragraph = UnoParagraph(text=combined_text)
 
-    expected_objects: list[Block] = [expected_paragraph]
+    expected_blocks = [expected_paragraph]
 
     _assert_rst_converts_to_notion_objects(
         rst_content=rst_content,
-        expected_objects=expected_objects,
+        expected_blocks=expected_blocks,
         make_app=make_app,
         tmp_path=tmp_path,
     )
@@ -586,11 +586,11 @@ def test_unnamed_link_with_backticks(
 
     expected_paragraph = UnoParagraph(text=combined_text)
 
-    expected_objects: list[Block] = [expected_paragraph]
+    expected_blocks = [expected_paragraph]
 
     _assert_rst_converts_to_notion_objects(
         rst_content=rst_content,
-        expected_objects=expected_objects,
+        expected_blocks=expected_blocks,
         make_app=make_app,
         tmp_path=tmp_path,
     )
@@ -609,13 +609,13 @@ def test_simple_quote(
 
             This is a block quote.
     """
-    expected_objects: list[Block] = [
+    expected_blocks = [
         UnoParagraph(text=text(text="Some content.")),
         UnoQuote(text=text(text="This is a block quote.")),
     ]
     _assert_rst_converts_to_notion_objects(
         rst_content=rst_content,
-        expected_objects=expected_objects,
+        expected_blocks=expected_blocks,
         make_app=make_app,
         tmp_path=tmp_path,
     )
@@ -636,7 +636,7 @@ def test_multiline_quote(
             block quote with
             multiple lines.
     """
-    expected_objects: list[Block] = [
+    expected_blocks = [
         UnoParagraph(text=text(text="Some content.")),
         UnoQuote(
             text=text(
@@ -646,7 +646,7 @@ def test_multiline_quote(
     ]
     _assert_rst_converts_to_notion_objects(
         rst_content=rst_content,
-        expected_objects=expected_objects,
+        expected_blocks=expected_blocks,
         make_app=make_app,
         tmp_path=tmp_path,
     )
@@ -689,14 +689,14 @@ def test_multi_paragraph_quote(
 
     quote.append(blocks=[nested_paragraph])
 
-    expected_objects: list[Block] = [
+    expected_blocks = [
         UnoParagraph(text=text(text="Some content.")),
         quote,
     ]
 
     _assert_rst_converts_to_notion_objects(
         rst_content=rst_content,
-        expected_objects=expected_objects,
+        expected_blocks=expected_blocks,
         make_app=make_app,
         tmp_path=tmp_path,
     )
@@ -722,7 +722,7 @@ def test_table_of_contents(
         Second Section
         --------------
     """
-    expected_objects: list[Block] = [
+    expected_blocks = [
         UnoHeading1(text=text(text="Introduction")),
         UnoTableOfContents(),
         UnoHeading2(text=text(text="First Section")),
@@ -730,7 +730,7 @@ def test_table_of_contents(
     ]
     _assert_rst_converts_to_notion_objects(
         rst_content=rst_content,
-        expected_objects=expected_objects,
+        expected_blocks=expected_blocks,
         make_app=make_app,
         tmp_path=tmp_path,
     )
@@ -751,13 +751,13 @@ def test_toctree_directive(
         .. toctree::
     """
 
-    expected_objects: list[Block] = [
+    expected_blocks = [
         UnoHeading1(text=text(text="Introduction")),
     ]
 
     _assert_rst_converts_to_notion_objects(
         rst_content=rst_content,
-        expected_objects=expected_objects,
+        expected_blocks=expected_blocks,
         make_app=make_app,
         tmp_path=tmp_path,
     )
@@ -777,7 +777,7 @@ def test_simple_code_block(
            def hello():
                print("Hello, world!")
     """
-    expected_objects: list[Block] = [
+    expected_blocks = [
         UnoCode(
             text=text(text='def hello():\n    print("Hello, world!")'),
             language=CodeLang.PYTHON,
@@ -785,7 +785,7 @@ def test_simple_code_block(
     ]
     _assert_rst_converts_to_notion_objects(
         rst_content=rst_content,
-        expected_objects=expected_objects,
+        expected_blocks=expected_blocks,
         make_app=make_app,
         tmp_path=tmp_path,
     )
@@ -820,7 +820,7 @@ def test_code_block_language_mapping(
 
            Code with no language
     """
-    expected_objects: list[Block] = [
+    expected_blocks = [
         UnoCode(
             text=text(text="$ pip install example"), language=CodeLang.SHELL
         ),
@@ -839,7 +839,7 @@ def test_code_block_language_mapping(
     ]
     _assert_rst_converts_to_notion_objects(
         rst_content=rst_content,
-        expected_objects=expected_objects,
+        expected_blocks=expected_blocks,
         make_app=make_app,
         tmp_path=tmp_path,
     )
@@ -858,14 +858,14 @@ def test_flat_bullet_list(
         * Second bullet point
         * Third bullet point with longer text
     """
-    expected_objects: list[Block] = [
+    expected_blocks = [
         UnoBulletedItem(text=text(text="First bullet point")),
         UnoBulletedItem(text=text(text="Second bullet point")),
         UnoBulletedItem(text=text(text="Third bullet point with longer text")),
     ]
     _assert_rst_converts_to_notion_objects(
         rst_content=rst_content,
-        expected_objects=expected_objects,
+        expected_blocks=expected_blocks,
         make_app=make_app,
         tmp_path=tmp_path,
     )
@@ -890,13 +890,13 @@ def test_bullet_list_with_inline_formatting(
         )
     )
 
-    expected_objects: list[Block] = [
+    expected_blocks = [
         bullet,
     ]
 
     _assert_rst_converts_to_notion_objects(
         rst_content=rst_content,
-        expected_objects=expected_objects,
+        expected_blocks=expected_blocks,
         make_app=make_app,
         tmp_path=tmp_path,
     )
@@ -938,12 +938,12 @@ def test_admonition_single_line(
         color=background_color,
     )
 
-    expected_objects: list[Block] = [
+    expected_blocks = [
         callout,
     ]
     _assert_rst_converts_to_notion_objects(
         rst_content=rst_content,
-        expected_objects=expected_objects,
+        expected_blocks=expected_blocks,
         make_app=make_app,
         tmp_path=tmp_path,
     )
@@ -990,12 +990,12 @@ def test_admonition_multiline(
 
     callout.append(blocks=[nested_paragraph])
 
-    expected_objects: list[Block] = [
+    expected_blocks = [
         callout,
     ]
     _assert_rst_converts_to_notion_objects(
         rst_content=rst_content,
-        expected_objects=expected_objects,
+        expected_blocks=expected_blocks,
         make_app=make_app,
         tmp_path=tmp_path,
     )
@@ -1038,12 +1038,12 @@ def test_admonition_with_code_block(
     callout.append(blocks=[nested_code_block])
     callout.append(blocks=[nested_paragraph])
 
-    expected_objects: list[Block] = [
+    expected_blocks = [
         callout,
     ]
     _assert_rst_converts_to_notion_objects(
         rst_content=rst_content,
-        expected_objects=expected_objects,
+        expected_blocks=expected_blocks,
         make_app=make_app,
         tmp_path=tmp_path,
     )
@@ -1087,10 +1087,10 @@ def test_admonition_with_code_block_first(
     callout.append(blocks=[nested_code_block])
     callout.append(blocks=[nested_paragraph])
 
-    expected_objects: list[Block] = [callout]
+    expected_blocks = [callout]
     _assert_rst_converts_to_notion_objects(
         rst_content=rst_content,
-        expected_objects=expected_objects,
+        expected_blocks=expected_blocks,
         make_app=make_app,
         tmp_path=tmp_path,
     )
@@ -1129,13 +1129,13 @@ def test_admonition_with_bullet_points(
     callout.append(blocks=[bullet_a])
     callout.append(blocks=[bullet_b])
 
-    expected_objects: list[Block] = [
+    expected_blocks = [
         callout,
     ]
 
     _assert_rst_converts_to_notion_objects(
         rst_content=rst_content,
-        expected_objects=expected_objects,
+        expected_blocks=expected_blocks,
         make_app=make_app,
         tmp_path=tmp_path,
     )
@@ -1175,13 +1175,13 @@ def test_generic_admonition(
     callout.append(blocks=[nested_paragraph1])
     callout.append(blocks=[nested_paragraph2])
 
-    expected_objects: list[Block] = [
+    expected_blocks = [
         callout,
     ]
 
     _assert_rst_converts_to_notion_objects(
         rst_content=rst_content,
-        expected_objects=expected_objects,
+        expected_blocks=expected_blocks,
         make_app=make_app,
         tmp_path=tmp_path,
     )
@@ -1225,7 +1225,7 @@ def test_nested_bullet_list(
 
     top_level_3 = UnoBulletedItem(text=text(text="Another top level item"))
 
-    expected_objects: list[Block] = [
+    expected_blocks = [
         top_level_1,
         top_level_2,
         top_level_3,
@@ -1233,7 +1233,7 @@ def test_nested_bullet_list(
 
     _assert_rst_converts_to_notion_objects(
         rst_content=rst_content,
-        expected_objects=expected_objects,
+        expected_blocks=expected_blocks,
         make_app=make_app,
         tmp_path=tmp_path,
         extensions=("sphinx_notion", "sphinx_toolbox.collapse"),
@@ -1253,7 +1253,7 @@ def test_flat_numbered_list(
         2. Second numbered point
         3. Third numbered point with longer text
     """
-    expected_objects: list[Block] = [
+    expected_blocks = [
         UnoNumberedItem(text=text(text="First numbered point")),
         UnoNumberedItem(text=text(text="Second numbered point")),
         UnoNumberedItem(
@@ -1262,7 +1262,7 @@ def test_flat_numbered_list(
     ]
     _assert_rst_converts_to_notion_objects(
         rst_content=rst_content,
-        expected_objects=expected_objects,
+        expected_blocks=expected_blocks,
         make_app=make_app,
         tmp_path=tmp_path,
     )
@@ -1292,13 +1292,13 @@ def test_numbered_list_with_inline_formatting(
         )
     )
 
-    expected_objects: list[Block] = [
+    expected_blocks = [
         numbered_item,
     ]
 
     _assert_rst_converts_to_notion_objects(
         rst_content=rst_content,
-        expected_objects=expected_objects,
+        expected_blocks=expected_blocks,
         make_app=make_app,
         tmp_path=tmp_path,
     )
@@ -1342,7 +1342,7 @@ def test_nested_numbered_list(
 
     top_level_3 = UnoNumberedItem(text=text(text="Another top level item"))
 
-    expected_objects: list[Block] = [
+    expected_blocks = [
         top_level_1,
         top_level_2,
         top_level_3,
@@ -1350,7 +1350,7 @@ def test_nested_numbered_list(
 
     _assert_rst_converts_to_notion_objects(
         rst_content=rst_content,
-        expected_objects=expected_objects,
+        expected_blocks=expected_blocks,
         make_app=make_app,
         tmp_path=tmp_path,
     )
@@ -1389,13 +1389,13 @@ def test_collapse_block(
     toggle_block.append(blocks=[nested_para1])
     toggle_block.append(blocks=[nested_para2])
 
-    expected_objects: list[Block] = [
+    expected_blocks = [
         toggle_block,
     ]
 
     _assert_rst_converts_to_notion_objects(
         rst_content=rst_content,
-        expected_objects=expected_objects,
+        expected_blocks=expected_blocks,
         make_app=make_app,
         tmp_path=tmp_path,
         extensions=("sphinx_notion", "sphinx_toolbox.collapse"),
@@ -1433,11 +1433,11 @@ def test_simple_table(
     table[2, 0] = text(text="Cell 3") + text(text="\n\n") + text(text="Cell 3")
     table[2, 1] = text(text="Cell 4") + text(text="\n\n") + text(text="Cell 4")
 
-    expected_objects: list[Block] = [table]
+    expected_blocks = [table]
 
     _assert_rst_converts_to_notion_objects(
         rst_content=rst_content,
-        expected_objects=expected_objects,
+        expected_blocks=expected_blocks,
         make_app=make_app,
         tmp_path=tmp_path,
     )
@@ -1464,11 +1464,11 @@ def test_table_without_header_row(
     table[1, 0] = text(text="Cell 3")
     table[1, 1] = text(text="Cell 4")
 
-    expected_objects: list[Block] = [table]
+    expected_blocks = [table]
 
     _assert_rst_converts_to_notion_objects(
         rst_content=rst_content,
-        expected_objects=expected_objects,
+        expected_blocks=expected_blocks,
         make_app=make_app,
         tmp_path=tmp_path,
     )
@@ -1498,11 +1498,11 @@ def test_table_inline_formatting(
     table[1, 0] = text(text="cell code", code=True)
     table[1, 1] = text(text="Normal cell")
 
-    expected_objects: list[Block] = [table]
+    expected_blocks = [table]
 
     _assert_rst_converts_to_notion_objects(
         rst_content=rst_content,
-        expected_objects=expected_objects,
+        expected_blocks=expected_blocks,
         make_app=make_app,
         tmp_path=tmp_path,
     )
@@ -1536,7 +1536,7 @@ def test_table_cell_non_paragraph_error(
     with pytest.raises(expected_exception=ValueError, match=expected_message):
         _assert_rst_converts_to_notion_objects(
             rst_content=rst_content,
-            expected_objects=[],
+            expected_blocks=[],
             make_app=make_app,
             tmp_path=tmp_path,
         )
@@ -1554,7 +1554,7 @@ def test_simple_image(
         .. image:: https://www.example.com/path/to/image.png
     """
 
-    expected_objects: list[Block] = [
+    expected_blocks = [
         UnoImage(
             file=ExternalFile(url="https://www.example.com/path/to/image.png")
         ),
@@ -1562,7 +1562,7 @@ def test_simple_image(
 
     _assert_rst_converts_to_notion_objects(
         rst_content=rst_content,
-        expected_objects=expected_objects,
+        expected_blocks=expected_blocks,
         make_app=make_app,
         tmp_path=tmp_path,
     )
@@ -1582,7 +1582,7 @@ def test_image_with_alt_text_only(
            :alt: Example image
     """
 
-    expected_objects: list[Block] = [
+    expected_blocks = [
         UnoImage(
             file=ExternalFile(url="https://www.example.com/path/to/image.png"),
         ),
@@ -1590,7 +1590,7 @@ def test_image_with_alt_text_only(
 
     _assert_rst_converts_to_notion_objects(
         rst_content=rst_content,
-        expected_objects=expected_objects,
+        expected_blocks=expected_blocks,
         make_app=make_app,
         tmp_path=tmp_path,
     )
@@ -1615,7 +1615,7 @@ def test_literalinclude_without_caption(
         """,
     )
 
-    expected_objects: list[Block] = [
+    expected_blocks = [
         UnoCode(
             text=text(text=conf_py_content),
             language=CodeLang.PYTHON,
@@ -1624,7 +1624,7 @@ def test_literalinclude_without_caption(
 
     _assert_rst_converts_to_notion_objects(
         rst_content=rst_content,
-        expected_objects=expected_objects,
+        expected_blocks=expected_blocks,
         make_app=make_app,
         tmp_path=tmp_path,
         conf_py_content=conf_py_content,
@@ -1657,7 +1657,7 @@ def test_literalinclude_with_caption(
     normal_text = text(text=" Configuration File")
     caption_with_bold = bold_text + normal_text
 
-    expected_objects: list[Block] = [
+    expected_blocks = [
         UnoCode(
             text=text(text=conf_py_content),
             language=CodeLang.PYTHON,
@@ -1667,7 +1667,7 @@ def test_literalinclude_with_caption(
 
     _assert_rst_converts_to_notion_objects(
         rst_content=rst_content,
-        expected_objects=expected_objects,
+        expected_blocks=expected_blocks,
         make_app=make_app,
         tmp_path=tmp_path,
         conf_py_content=conf_py_content,
@@ -1709,7 +1709,7 @@ def test_heading_level_4_error(
     ):
         _assert_rst_converts_to_notion_objects(
             rst_content=rst_content,
-            expected_objects=[],
+            expected_blocks=[],
             make_app=make_app,
             tmp_path=tmp_path,
         )
@@ -1735,13 +1735,13 @@ def test_local_image_file(
         .. image:: test_image.png
     """
 
-    expected_objects: list[Block] = [
+    expected_blocks = [
         UnoImage(file=ExternalFile(url=test_image_path.as_uri())),
     ]
 
     _assert_rst_converts_to_notion_objects(
         rst_content=rst_content,
-        expected_objects=expected_objects,
+        expected_blocks=expected_blocks,
         make_app=make_app,
         tmp_path=tmp_path,
     )
@@ -1759,7 +1759,7 @@ def test_simple_video(
         .. video:: https://www.example.com/path/to/video.mp4
     """
 
-    expected_objects: list[Block] = [
+    expected_blocks = [
         UnoVideo(
             file=ExternalFile(url="https://www.example.com/path/to/video.mp4")
         ),
@@ -1767,7 +1767,7 @@ def test_simple_video(
 
     _assert_rst_converts_to_notion_objects(
         rst_content=rst_content,
-        expected_objects=expected_objects,
+        expected_blocks=expected_blocks,
         make_app=make_app,
         tmp_path=tmp_path,
         extensions=("sphinxcontrib.video", "sphinx_notion"),
@@ -1788,7 +1788,7 @@ def test_video_with_caption(
            :caption: Example video
     """
 
-    expected_objects: list[Block] = [
+    expected_blocks = [
         UnoVideo(
             file=ExternalFile(url="https://www.example.com/path/to/video.mp4"),
             caption=text(text="Example video"),
@@ -1797,7 +1797,7 @@ def test_video_with_caption(
 
     _assert_rst_converts_to_notion_objects(
         rst_content=rst_content,
-        expected_objects=expected_objects,
+        expected_blocks=expected_blocks,
         make_app=make_app,
         tmp_path=tmp_path,
         extensions=("sphinxcontrib.video", "sphinx_notion"),
@@ -1822,13 +1822,13 @@ def test_local_video_file(
         .. video:: test_video.mp4
     """
 
-    expected_objects: list[Block] = [
+    expected_blocks = [
         UnoVideo(file=ExternalFile(url=test_video_path.as_uri())),
     ]
 
     _assert_rst_converts_to_notion_objects(
         rst_content=rst_content,
-        expected_objects=expected_objects,
+        expected_blocks=expected_blocks,
         make_app=make_app,
         tmp_path=tmp_path,
         extensions=("sphinx_notion", "sphinxcontrib.video"),
@@ -1847,7 +1847,7 @@ def test_simple_audio(
         .. audio:: https://www.example.com/path/to/audio.mp3
     """
 
-    expected_objects: list[Block] = [
+    expected_blocks = [
         UnoAudio(
             file=ExternalFile(url="https://www.example.com/path/to/audio.mp3")
         ),
@@ -1855,7 +1855,7 @@ def test_simple_audio(
 
     _assert_rst_converts_to_notion_objects(
         rst_content=rst_content,
-        expected_objects=expected_objects,
+        expected_blocks=expected_blocks,
         make_app=make_app,
         tmp_path=tmp_path,
         extensions=("sphinx_notion", "atsphinx.audioplayer"),
@@ -1880,13 +1880,13 @@ def test_local_audio_file(
         .. audio:: test_audio.mp3
     """
 
-    expected_objects: list[Block] = [
+    expected_blocks = [
         UnoAudio(file=ExternalFile(url=test_audio_path.as_uri())),
     ]
 
     _assert_rst_converts_to_notion_objects(
         rst_content=rst_content,
-        expected_objects=expected_objects,
+        expected_blocks=expected_blocks,
         make_app=make_app,
         tmp_path=tmp_path,
         extensions=("sphinx_notion", "atsphinx.audioplayer"),
@@ -1915,14 +1915,14 @@ def test_strikethrough_text(
 
     combined_text = normal_text1 + strikethrough_text + normal_text2
 
-    expected_objects: list[Block] = [
+    expected_blocks = [
         UnoParagraph(text=combined_text),
         UnoParagraph(text=combined_text),
     ]
 
     _assert_rst_converts_to_notion_objects(
         rst_content=rst_content,
-        expected_objects=expected_objects,
+        expected_blocks=expected_blocks,
         make_app=make_app,
         tmp_path=tmp_path,
         extensions=(
@@ -1949,7 +1949,7 @@ def test_comment_ignored(
         This is another paragraph after the comment.
     """
 
-    expected_objects: list[Block] = [
+    expected_blocks = [
         UnoParagraph(text=text(text="This is a paragraph with content.")),
         UnoParagraph(
             text=text(text="This is another paragraph after the comment.")
@@ -1958,7 +1958,7 @@ def test_comment_ignored(
 
     _assert_rst_converts_to_notion_objects(
         rst_content=rst_content,
-        expected_objects=expected_objects,
+        expected_blocks=expected_blocks,
         make_app=make_app,
         tmp_path=tmp_path,
     )
@@ -1988,11 +1988,11 @@ def test_list_table_header_one_allowed(
     table[1, 0] = text(text="Cell 1")
     table[1, 1] = text(text="Cell 2")
 
-    expected_objects: list[Block] = [table]
+    expected_blocks = [table]
 
     _assert_rst_converts_to_notion_objects(
         rst_content=rst_content,
-        expected_objects=expected_objects,
+        expected_blocks=expected_blocks,
         make_app=make_app,
         tmp_path=tmp_path,
     )
@@ -2018,11 +2018,11 @@ def test_list_table_header_rows_zero_allowed(
     table[0, 0] = text(text="Cell 1")
     table[0, 1] = text(text="Cell 2")
 
-    expected_objects: list[Block] = [table]
+    expected_blocks = [table]
 
     _assert_rst_converts_to_notion_objects(
         rst_content=rst_content,
-        expected_objects=expected_objects,
+        expected_blocks=expected_blocks,
         make_app=make_app,
         tmp_path=tmp_path,
     )
@@ -2062,11 +2062,11 @@ def test_list_table_header_maximum_one_allowed(
     table[2, 0] = text(text="Cell a 1")
     table[2, 1] = text(text="Cell a 2")
 
-    expected_objects: list[Block] = [table]
+    expected_blocks = [table]
 
     _assert_rst_converts_to_notion_objects(
         rst_content=rst_content,
-        expected_objects=expected_objects,
+        expected_blocks=expected_blocks,
         make_app=make_app,
         tmp_path=tmp_path,
         expected_warnings=[expected_warning],
@@ -2111,11 +2111,11 @@ def test_list_table_stub_columns_one(
     table[2, 1] = text(text="Row 2, Col 2")
     table[2, 2] = text(text="Row 2, Col 3")
 
-    expected_objects: list[Block] = [table]
+    expected_blocks = [table]
 
     _assert_rst_converts_to_notion_objects(
         rst_content=rst_content,
-        expected_objects=expected_objects,
+        expected_blocks=expected_blocks,
         make_app=make_app,
         tmp_path=tmp_path,
     )
@@ -2162,11 +2162,11 @@ def test_list_table_stub_columns_two(
     table[2, 1] = text(text="Row 2, Col 2")
     table[2, 2] = text(text="Row 2, Col 3")
 
-    expected_objects: list[Block] = [table]
+    expected_blocks = [table]
 
     _assert_rst_converts_to_notion_objects(
         rst_content=rst_content,
-        expected_objects=expected_objects,
+        expected_blocks=expected_blocks,
         make_app=make_app,
         tmp_path=tmp_path,
         expected_warnings=[expected_warning],
@@ -2204,11 +2204,11 @@ def test_list_table_with_title_error(
     table[1, 0] = text(text="Cell 1")
     table[1, 1] = text(text="Cell 2")
 
-    expected_objects: list[Block] = [table]
+    expected_blocks = [table]
 
     _assert_rst_converts_to_notion_objects(
         rst_content=rst_content,
-        expected_objects=expected_objects,
+        expected_blocks=expected_blocks,
         make_app=make_app,
         tmp_path=tmp_path,
         expected_warnings=[expected_warning],
@@ -2236,7 +2236,7 @@ def test_simple_pdf(
         .. pdf-include:: https://www.example.com/path/to/document.pdf
     """
 
-    expected_objects: list[Block] = [
+    expected_blocks = [
         UnoPDF(
             file=ExternalFile(
                 url="https://www.example.com/path/to/document.pdf"
@@ -2246,7 +2246,7 @@ def test_simple_pdf(
 
     _assert_rst_converts_to_notion_objects(
         rst_content=rst_content,
-        expected_objects=expected_objects,
+        expected_blocks=expected_blocks,
         make_app=make_app,
         tmp_path=tmp_path,
         extensions=extensions,
@@ -2267,7 +2267,7 @@ def test_pdf_with_options(
            :height: 300px
     """
 
-    expected_objects: list[Block] = [
+    expected_blocks = [
         UnoPDF(
             file=ExternalFile(
                 url="https://www.example.com/path/to/document.pdf"
@@ -2277,7 +2277,7 @@ def test_pdf_with_options(
 
     _assert_rst_converts_to_notion_objects(
         rst_content=rst_content,
-        expected_objects=expected_objects,
+        expected_blocks=expected_blocks,
         make_app=make_app,
         tmp_path=tmp_path,
         extensions=("sphinx_notion",),
@@ -2302,13 +2302,13 @@ def test_local_pdf_file(
         .. pdf-include:: test_document.pdf
     """
 
-    expected_objects: list[Block] = [
+    expected_blocks = [
         UnoPDF(file=ExternalFile(url=test_pdf_path.as_uri())),
     ]
 
     _assert_rst_converts_to_notion_objects(
         rst_content=rst_content,
-        expected_objects=expected_objects,
+        expected_blocks=expected_blocks,
         make_app=make_app,
         tmp_path=tmp_path,
         extensions=("sphinx_notion",),
@@ -2393,11 +2393,11 @@ and :text-green:`green text`.
 
     expected_paragraph = UnoParagraph(text=combined_text)
 
-    expected_objects: list[Block] = [expected_paragraph]
+    expected_blocks = [expected_paragraph]
 
     _assert_rst_converts_to_notion_objects(
         rst_content=rst_content,
-        expected_objects=expected_objects,
+        expected_blocks=expected_blocks,
         make_app=make_app,
         tmp_path=tmp_path,
         extensions=("sphinx_notion", "sphinxcontrib_text_styles"),
@@ -2454,11 +2454,11 @@ def test_individual_colors(
 
     expected_paragraph = UnoParagraph(text=combined_text)
 
-    expected_objects: list[Block] = [expected_paragraph]
+    expected_blocks = [expected_paragraph]
 
     _assert_rst_converts_to_notion_objects(
         rst_content=rst_content,
-        expected_objects=expected_objects,
+        expected_blocks=expected_blocks,
         make_app=make_app,
         tmp_path=tmp_path,
         extensions=("sphinx_notion", "sphinxcontrib_text_styles"),
@@ -2491,11 +2491,11 @@ def test_text_styles_unsupported_color(
 
     expected_paragraph = UnoParagraph(text=combined_text)
 
-    expected_objects: list[Block] = [expected_paragraph]
+    expected_blocks = [expected_paragraph]
 
     _assert_rst_converts_to_notion_objects(
         rst_content=rst_content,
-        expected_objects=expected_objects,
+        expected_blocks=expected_blocks,
         make_app=make_app,
         tmp_path=tmp_path,
         extensions=("sphinx_notion", "sphinxcontrib_text_styles"),
@@ -2535,11 +2535,11 @@ def setup(app):
 
     expected_paragraph = UnoParagraph(text=combined_text)
 
-    expected_objects: list[Block] = [expected_paragraph]
+    expected_blocks = [expected_paragraph]
 
     _assert_rst_converts_to_notion_objects(
         rst_content=rst_content,
-        expected_objects=expected_objects,
+        expected_blocks=expected_blocks,
         make_app=make_app,
         tmp_path=tmp_path,
         conf_py_content=conf_py_content,
@@ -2576,11 +2576,11 @@ def test_text_styles_and_strike(
 
     expected_paragraph = UnoParagraph(text=combined_text)
 
-    expected_objects: list[Block] = [expected_paragraph]
+    expected_blocks = [expected_paragraph]
 
     _assert_rst_converts_to_notion_objects(
         rst_content=rst_content,
-        expected_objects=expected_objects,
+        expected_blocks=expected_blocks,
         make_app=make_app,
         tmp_path=tmp_path,
         extensions=(
@@ -2623,11 +2623,11 @@ def test_additional_text_styles(
 
     expected_paragraph = UnoParagraph(text=combined_text)
 
-    expected_objects: list[Block] = [expected_paragraph]
+    expected_blocks = [expected_paragraph]
 
     _assert_rst_converts_to_notion_objects(
         rst_content=rst_content,
-        expected_objects=expected_objects,
+        expected_blocks=expected_blocks,
         make_app=make_app,
         tmp_path=tmp_path,
         extensions=("sphinx_notion", "sphinxcontrib_text_styles"),
@@ -2649,7 +2649,7 @@ def test_flat_task_list(
            - [x] Checked task item
            - [ ] Another unchecked task with **bold text**
     """
-    expected_objects: list[Block] = [
+    expected_blocks = [
         UnoToDoItem(text=text(text="Unchecked task item"), checked=False),
         UnoToDoItem(text=text(text="Checked task item"), checked=True),
         UnoToDoItem(
@@ -2662,7 +2662,7 @@ def test_flat_task_list(
     ]
     _assert_rst_converts_to_notion_objects(
         rst_content=rst_content,
-        expected_objects=expected_objects,
+        expected_blocks=expected_blocks,
         make_app=make_app,
         tmp_path=tmp_path,
         extensions=("sphinx_notion", "sphinx_immaterial.task_lists"),
@@ -2710,13 +2710,13 @@ def test_bullet_list_with_nested_content(
     )
     second_bullet.append(blocks=[nested_paragraph_2])
 
-    expected_objects: list[Block] = [
+    expected_blocks = [
         first_bullet,
         second_bullet,
     ]
     _assert_rst_converts_to_notion_objects(
         rst_content=rst_content,
-        expected_objects=expected_objects,
+        expected_blocks=expected_blocks,
         make_app=make_app,
         tmp_path=tmp_path,
     )
@@ -2758,11 +2758,11 @@ def test_task_list_with_nested_content(
     )
     task_item.append(blocks=[nested_bullet])
 
-    expected_objects: list[Block] = [task_item]
+    expected_blocks = [task_item]
 
     _assert_rst_converts_to_notion_objects(
         rst_content=rst_content,
-        expected_objects=expected_objects,
+        expected_blocks=expected_blocks,
         make_app=make_app,
         tmp_path=tmp_path,
         extensions=("sphinx_notion", "sphinx_immaterial.task_lists"),
@@ -2825,14 +2825,14 @@ def test_nested_task_list(
     )
     task_b.append(blocks=[another_bullet])
 
-    expected_objects: list[Block] = [
+    expected_blocks = [
         UnoToDoItem(text=text(text="Task A"), checked=True),
         task_b,
         UnoToDoItem(text=text(text="Task C"), checked=False),
     ]
     _assert_rst_converts_to_notion_objects(
         rst_content=rst_content,
-        expected_objects=expected_objects,
+        expected_blocks=expected_blocks,
         make_app=make_app,
         tmp_path=tmp_path,
         extensions=("sphinx_notion", "sphinx_immaterial.task_lists"),
@@ -2858,7 +2858,7 @@ def test_task_list_quote(
 
     # The actual processing creates a flat structure where the quote
     # becomes a separate quote block
-    expected_objects: list[Block] = [
+    expected_blocks = [
         UnoToDoItem(text=text(text="Task A"), checked=True),
         UnoToDoItem(text=text(text="Task B"), checked=False),
         UnoQuote(text=text(text="foo")),
@@ -2866,7 +2866,7 @@ def test_task_list_quote(
 
     _assert_rst_converts_to_notion_objects(
         rst_content=rst_content,
-        expected_objects=expected_objects,
+        expected_blocks=expected_blocks,
         make_app=make_app,
         tmp_path=tmp_path,
         extensions=("sphinx_notion", "sphinx_immaterial.task_lists"),
@@ -2884,12 +2884,12 @@ def test_inline_single_backticks(
     rst_content = """
         A `B`
     """
-    expected_objects: list[Block] = [
+    expected_blocks = [
         UnoParagraph(text=text(text="A ") + text(text="B", italic=True)),
     ]
     _assert_rst_converts_to_notion_objects(
         rst_content=rst_content,
-        expected_objects=expected_objects,
+        expected_blocks=expected_blocks,
         make_app=make_app,
         tmp_path=tmp_path,
     )
@@ -2933,11 +2933,11 @@ def test_kbd_role(
 
     expected_paragraph = UnoParagraph(text=combined_text)
 
-    expected_objects: list[Block] = [expected_paragraph]
+    expected_blocks = [expected_paragraph]
 
     _assert_rst_converts_to_notion_objects(
         rst_content=rst_content,
-        expected_objects=expected_objects,
+        expected_blocks=expected_blocks,
         make_app=make_app,
         tmp_path=tmp_path,
     )
@@ -2964,11 +2964,11 @@ def test_file_role(
 
     expected_paragraph = UnoParagraph(text=combined_text)
 
-    expected_objects: list[Block] = [expected_paragraph]
+    expected_blocks = [expected_paragraph]
 
     _assert_rst_converts_to_notion_objects(
         rst_content=rst_content,
-        expected_objects=expected_objects,
+        expected_blocks=expected_blocks,
         make_app=make_app,
         tmp_path=tmp_path,
     )
@@ -3005,7 +3005,7 @@ def setup(app):
     with pytest.raises(expected_exception=ValueError, match=expected_message):
         _assert_rst_converts_to_notion_objects(
             rst_content=rst_content,
-            expected_objects=[],
+            expected_blocks=[],
             make_app=make_app,
             tmp_path=tmp_path,
             conf_py_content=conf_py_content,
@@ -3051,7 +3051,7 @@ def test_unsupported_node_types_in_process_node_to_blocks(
     ):
         _assert_rst_converts_to_notion_objects(
             rst_content=rst_content,
-            expected_objects=[],
+            expected_blocks=[],
             make_app=make_app,
             tmp_path=tmp_path,
         )
@@ -3077,11 +3077,11 @@ def test_inline_equation(
 
     expected_paragraph = UnoParagraph(text=combined_text)
 
-    expected_objects: list[Block] = [expected_paragraph]
+    expected_blocks = [expected_paragraph]
 
     _assert_rst_converts_to_notion_objects(
         rst_content=rst_content,
-        expected_objects=expected_objects,
+        expected_blocks=expected_blocks,
         make_app=make_app,
         tmp_path=tmp_path,
         extensions=("sphinx_notion", "sphinx.ext.mathjax"),
@@ -3102,13 +3102,13 @@ def test_block_equation(
            E = mc^2
     """
 
-    expected_objects: list[Block] = [
+    expected_blocks = [
         UnoEquation(latex="E = mc^2"),
     ]
 
     _assert_rst_converts_to_notion_objects(
         rst_content=rst_content,
-        expected_objects=expected_objects,
+        expected_blocks=expected_blocks,
         make_app=make_app,
         tmp_path=tmp_path,
         extensions=("sphinx_notion", "sphinx.ext.mathjax"),
@@ -3181,11 +3181,11 @@ def test_rest_example_block(
     main_callout = UnoCallout(text=text(text="Example"))
     main_callout.append(blocks=[code_callout, output_callout])
 
-    expected_objects: list[Block] = [main_callout]
+    expected_blocks = [main_callout]
 
     _assert_rst_converts_to_notion_objects(
         rst_content=rst_content,
-        expected_objects=expected_objects,
+        expected_blocks=expected_blocks,
         make_app=make_app,
         tmp_path=tmp_path,
         extensions=("sphinx_notion", "sphinx_toolbox.rest_example"),
@@ -3206,7 +3206,7 @@ def test_embed_block(
            :height: 400
     """
 
-    expected_objects: list[Block] = [UnoEmbed(url="https://example.com/embed")]
+    expected_blocks = [UnoEmbed(url="https://example.com/embed")]
 
     # Create the _static directory that ``sphinx-iframes`` expects
     static_dir = tmp_path / "build" / "notion" / "_static"
@@ -3214,7 +3214,7 @@ def test_embed_block(
 
     _assert_rst_converts_to_notion_objects(
         rst_content=rst_content,
-        expected_objects=expected_objects,
+        expected_blocks=expected_blocks,
         make_app=make_app,
         tmp_path=tmp_path,
         extensions=("sphinx_notion", "sphinx_iframes"),
@@ -3239,14 +3239,14 @@ def test_embed_and_video(
         .. video:: https://example.com/video.mp4
     """
 
-    expected_objects: list[Block] = [
+    expected_blocks = [
         UnoEmbed(url="https://example.com/embed"),
         UnoVideo(file=ExternalFile(url="https://example.com/video.mp4")),
     ]
 
     _assert_rst_converts_to_notion_objects(
         rst_content=rst_content,
-        expected_objects=expected_objects,
+        expected_blocks=expected_blocks,
         make_app=make_app,
         tmp_path=tmp_path,
         extensions=("sphinxcontrib.video", "sphinx_iframes", "sphinx_notion"),
@@ -3268,7 +3268,7 @@ def test_line_block(
         | preserved exactly as written
     """
 
-    expected_objects: list[Block] = [
+    expected_blocks = [
         UnoParagraph(
             text=text(text="This is a line block")
             + text(text="\n")
@@ -3281,7 +3281,7 @@ def test_line_block(
 
     _assert_rst_converts_to_notion_objects(
         rst_content=rst_content,
-        expected_objects=expected_objects,
+        expected_blocks=expected_blocks,
         make_app=make_app,
         tmp_path=tmp_path,
     )
@@ -3303,7 +3303,7 @@ def test_transition_divider(
         Second paragraph.
     """
 
-    expected_objects: list[Block] = [
+    expected_blocks = [
         UnoParagraph(text=text(text="First paragraph.")),
         UnoDivider(),
         UnoParagraph(text=text(text="Second paragraph.")),
@@ -3311,7 +3311,7 @@ def test_transition_divider(
 
     _assert_rst_converts_to_notion_objects(
         rst_content=rst_content,
-        expected_objects=expected_objects,
+        expected_blocks=expected_blocks,
         make_app=make_app,
         tmp_path=tmp_path,
     )


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Refactors the test helper to accept `Sequence[Block]` and renames `expected_objects` to `expected_blocks`, updating all integration tests accordingly.
> 
> - **Tests (`tests/test_integration.py`)**:
>   - Refactor helper `_assert_rst_converts_to_notion_objects` to accept `expected_blocks: Sequence[Block]` (was `expected_objects: list[Block]`).
>   - Rename all usages of `expected_objects` to `expected_blocks` across tests.
>   - Add `Sequence` import from `collections.abc` to support the new type.
>   - No behavioral changes to test assertions or expected Notion block structures.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a46d265fe8be8e957dfe42776a08dbf7a8b591e5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->