### PR TITLE
Fail upload if page has sub-databases

### DIFF
--- a/src/_notion_scripts/upload.py
+++ b/src/_notion_scripts/upload.py
@@ -371,11 +371,18 @@ def main(
         page.cover = None
 
     if page.subpages:
-        non_block_page_child_error = (
+        page_has_page_child_error = (
             "We only support pages which only contain Blocks. "
             "This page has subpages."
         )
-        raise click.ClickException(message=non_block_page_child_error)
+        raise click.ClickException(message=page_has_page_child_error)
+
+    if page.subdbs:
+        page_has_database_child_error = (
+            "We only support pages which only contain Blocks. "
+            "This page has databases."
+        )
+        raise click.ClickException(message=page_has_database_child_error)
 
     block_objs = [
         Block.wrap_obj_ref(UnoObjAPIBlock.model_validate(obj=details))


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Abort upload if the target Notion page has child databases; subpage-only restriction remains.
> 
> - **Validation in `src/_notion_scripts/upload.py`**:
>   - Add check for `page.subdbs` and raise a `click.ClickException` when databases are present on the target page.
>   - Maintain existing error when `page.subpages` are present (variable name clarified).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 161d2fe0b08e7cccb747b8f8a29bb620feabc553. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->