### PR TITLE
Reduce API calls by using has_children

### DIFF
--- a/src/_notion_scripts/upload.py
+++ b/src/_notion_scripts/upload.py
@@ -41,7 +41,7 @@ def _block_without_children(
     Return a copy of a block without children.
     """
     serialized_block = block.obj_ref.serialize_for_api()
-    if block.blocks:
+    if block.has_children:
         serialized_block[serialized_block["type"]]["children"] = []
 
     # Delete the ID, else the block will have the children from Notion.
@@ -243,7 +243,7 @@ def _block_with_uploaded_file(*, block: Block, session: Session) -> Block:
 
             block = block.__class__(file=uploaded_file, caption=block.caption)
 
-    elif isinstance(block, ParentBlock) and block.blocks:
+    elif isinstance(block, ParentBlock) and block.has_children:
         new_child_blocks = [
             _block_with_uploaded_file(block=child_block, session=session)
             for child_block in block.blocks

--- a/src/sphinx_notion/__init__.py
+++ b/src/sphinx_notion/__init__.py
@@ -183,7 +183,7 @@ def _serialize_block_with_children(
     Convert a block to a JSON-serializable format which includes its children.
     """
     serialized_obj = block.obj_ref.serialize_for_api()
-    if isinstance(block, ParentBlock) and block.blocks:
+    if isinstance(block, ParentBlock) and block.has_children:
         serialized_obj[block.obj_ref.type]["children"] = [
             _serialize_block_with_children(block=child)
             for child in block.blocks

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -74,7 +74,7 @@ def _details_from_block(*, block: Block) -> dict[str, Any]:
     Create a serialized block details from a Block.
     """
     serialized_obj = block.obj_ref.serialize_for_api()
-    if isinstance(block, ParentBlock) and block.blocks:
+    if isinstance(block, ParentBlock) and block.has_children:
         serialized_obj[block.obj_ref.type]["children"] = [
             _details_from_block(block=child) for child in block.blocks
         ]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Replace `block.blocks` checks with `block.has_children` in upload, serialization, and tests to reduce unnecessary child fetching/API calls.
> 
> - **Notion block handling**:
>   - Switch child checks from `block.blocks` to `block.has_children` in `src/_notion_scripts/upload.py` (child stripping and recursive file upload) and `src/sphinx_notion/__init__.py` (recursive serialization).
> - **Tests**:
>   - Update `_details_from_block` in `tests/test_integration.py` to use `has_children` for building expected JSON.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 75b02cc9e79489adeddebf39a9f95aaf9e4f5442. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->