### PR TITLE
Pin sphinx-metadata-figure

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -337,7 +337,6 @@ pep621_dev_dependency_groups = [
 # Ignore sphinx-metadata-figure as it is a transitive dependency of sphinx-iframes
 # but we need to pin it explicitly due to a bug in 1.2.0+.
 # See: https://github.com/TeachBooks/Sphinx-Metadata-Figure/issues/30
-ignore = [ "DEP002" ]
 per_rule_ignores = { DEP002 = [ "sphinx-metadata-figure" ] }
 
 [tool.pyproject-fmt]


### PR DESCRIPTION
Avoid https://github.com/TeachBooks/Sphinx-Metadata-Figure/issues/30

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Pins `sphinx-metadata-figure` to `<1.2.0` and updates `deptry` config to ignore it as a transitive dependency.
> 
> - **Dependencies**:
>   - Pin `sphinx-metadata-figure<1.2.0` in `pyproject.toml`.
> - **Tooling/Config**:
>   - Add `deptry` `per_rule_ignores` for `DEP002` on `sphinx-metadata-figure`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b1ab2d9b84e31b83bd22b56d2ea29c41b0bc6cee. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->