### PR TITLE
Move mentions to the end

### DIFF
--- a/sample/index.rst
+++ b/sample/index.rst
@@ -68,37 +68,6 @@ Link to Notion Page Block
 
    .. notion-link-to-page:: 2a19ce7b60a4807dbae7c12161f12056
 
-Mentions
-~~~~~~~~
-
-User Mention
-^^^^^^^^^^^^
-
-.. rest-example::
-
-   Hello :notion-mention-user:`fc820d21-80ec-4d06-878c-f991bc8070d2` there!
-
-Page Mention
-^^^^^^^^^^^^
-
-.. rest-example::
-
-   See :notion-mention-page:`2a19ce7b60a4807dbae7c12161f12056` for more details.
-
-Database Mention
-^^^^^^^^^^^^^^^^
-
-.. rest-example::
-
-   Check the :notion-mention-database:`27d9ce7b60a4804b9c5cfa002668952b` database.
-
-Date Mention
-^^^^^^^^^^^^
-
-.. rest-example::
-
-   The meeting is scheduled for :notion-mention-date:`2025-11-09`.
-
 Admonitions
 ~~~~~~~~~~~
 
@@ -446,3 +415,38 @@ Line Blocks
    | This is a line block
    | with multiple lines
    | preserved exactly as written
+
+
+.. Keep this at the end as mention equality does not work
+.. https://github.com/ultimate-notion/ultimate-notion/issues/174
+
+Mentions
+~~~~~~~~
+
+User Mention
+^^^^^^^^^^^^
+
+.. rest-example::
+
+   Hello :notion-mention-user:`fc820d21-80ec-4d06-878c-f991bc8070d2` there!
+
+Page Mention
+^^^^^^^^^^^^
+
+.. rest-example::
+
+   See :notion-mention-page:`2a19ce7b60a4807dbae7c12161f12056` for more details.
+
+Database Mention
+^^^^^^^^^^^^^^^^
+
+.. rest-example::
+
+   Check the :notion-mention-database:`27d9ce7b60a4804b9c5cfa002668952b` database.
+
+Date Mention
+^^^^^^^^^^^^
+
+.. rest-example::
+
+   The meeting is scheduled for :notion-mention-date:`2025-11-09`.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Relocates the `Mentions` examples to the end of `sample/index.rst` and adds a note about keeping them last.
> 
> - **Docs**: Move the `Mentions` examples to the end of `sample/index.rst` and add a comment/note about keeping them last (with issue reference).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b313a14e6bb9f04e13e4491f2b0d346e77d3b6ee. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->