### PR TITLE
Switch from pre-commit to prek

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Run lint
         run: |
-          uv run --extra=dev --python=${{ matrix.python-version }} pre-commit run --all-files --hook-stage ${{ matrix.lint-stage }} --verbose
+          uv run --extra=dev --python=${{ matrix.python-version }} prek run --all-files --hook-stage ${{ matrix.lint-stage }} --verbose
 
       - name: Run tests
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,7 +44,7 @@ ci:
     - yamlfix
     - zizmor
 
-default_install_hook_types: [pre-commit, pre-push, commit-msg]
+default_install_hook_types: [pre-commit, pre-push]
 
 repos:
   - repo: meta

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ optional-dependencies.dev = [
     "interrogate==1.7.0",
     "mypy[faster-cache]==1.19.1",
     "mypy-strict-kwargs==2025.4.3",
-    "pre-commit==4.5.1",
+    "prek==0.2.25",
     "pydocstyle==6.3",
     "pygments==2.19.2",
     "pylint[spelling]==4.0.4",


### PR DESCRIPTION
Replace pre-commit with prek for running hooks.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches hook runner from pre-commit to prek and aligns configs.
> 
> - CI: `Run lint` now invokes `prek run` instead of `pre-commit run`
> - Dev deps: replace `pre-commit` with `prek` in `pyproject.toml`
> - `.pre-commit-config.yaml`: remove `commit-msg` from `default_install_hook_types`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fee67bfca858bea53e4cb986befb12d06af1943d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->