### PR TITLE
Make zizmor collection strict

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -122,8 +122,7 @@ repos:
 
       - id: shellcheck-docs
         name: shellcheck-docs
-        entry:
-          uv run --extra=dev doccmd --no-write-to-file --example-workers 0 --language=shell
+        entry: uv run --extra=dev doccmd --no-write-to-file --example-workers 0 --language=shell
           --language=console --command="shellcheck --shell=bash"
         language: python
         types_or: [markdown, rst]
@@ -140,8 +139,7 @@ repos:
 
       - id: shfmt-docs
         name: shfmt-docs
-        entry:
-          uv run --extra=dev doccmd --language=shell --language=console --skip-marker=shfmt
+        entry: uv run --extra=dev doccmd --language=shell --language=console --skip-marker=shfmt
           --no-pad-file --command="shfmt --write --space-redirects --indent=4"
         language: python
         types_or: [markdown, rst]
@@ -185,8 +183,7 @@ repos:
       - id: pyright-docs
         name: pyright-docs
         stages: [pre-push]
-        entry:
-          uv run --extra=dev doccmd --no-write-to-file --example-workers 0 --language=python
+        entry: uv run --extra=dev doccmd --no-write-to-file --example-workers 0 --language=python
           --command="pyright"
         language: python
         types_or: [markdown, rst]
@@ -203,8 +200,7 @@ repos:
 
       - id: vulture-docs
         name: vulture docs
-        entry:
-          uv run --extra=dev doccmd --no-write-to-file --example-workers 0 --language=python
+        entry: uv run --extra=dev doccmd --no-write-to-file --example-workers 0 --language=python
           --command="vulture"
         language: python
         types_or: [markdown, rst]
@@ -238,8 +234,7 @@ repos:
 
       - id: pylint-docs
         name: pylint-docs
-        entry:
-          uv run --extra=dev doccmd --no-write-to-file --example-workers 0 --language=python
+        entry: uv run --extra=dev doccmd --no-write-to-file --example-workers 0 --language=python
           --command="pylint"
         language: python
         stages: [manual]
@@ -272,8 +267,7 @@ repos:
 
       - id: ruff-format-fix-docs
         name: Ruff format docs
-        entry:
-          uv run --extra=dev doccmd --language=python --no-pad-file --command="ruff
+        entry: uv run --extra=dev doccmd --language=python --no-pad-file --command="ruff
           format"
         language: python
         types_or: [markdown, rst]
@@ -298,8 +292,7 @@ repos:
 
       - id: interrogate-docs
         name: interrogate docs
-        entry:
-          uv run --extra=dev doccmd --no-write-to-file --example-workers 0 --language=python
+        entry: uv run --extra=dev doccmd --no-write-to-file --example-workers 0 --language=python
           --command="interrogate"
         language: python
         types_or: [markdown, rst]
@@ -370,8 +363,7 @@ repos:
       - id: ty-docs
         name: ty-docs
         stages: [pre-push]
-        entry:
-          uv run --extra=dev doccmd --no-write-to-file --example-workers 0 --language=python
+        entry: uv run --extra=dev doccmd --no-write-to-file --example-workers 0 --language=python
           --command="ty check"
         language: python
         types_or: [markdown, rst]
@@ -389,8 +381,7 @@ repos:
       - id: pyrefly-docs
         name: pyrefly-docs
         stages: [pre-push]
-        entry:
-          uv run --extra=dev doccmd --no-write-to-file --example-workers 0 --language=python
+        entry: uv run --extra=dev doccmd --no-write-to-file --example-workers 0 --language=python
           --command="pyrefly check"
         language: python
         types_or: [markdown, rst]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Tightens GitHub Actions scanning in pre-commit.
> 
> - Updates `zizmor` hook to run `--strict-collection` against `.github`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e2654d9ca8e2d82f43e8687ed72072c6bde9d471. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->