### PR TITLE
Fix zizmor warning in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,8 +58,8 @@ jobs:
         uses: jacobtomlinson/gha-find-replace@v3
         with:
           find: "Next\n----"
-          replace: "Next\n----\n\n${{ steps.calver.outputs.release }}\n${{ steps.changelog_underline.outputs.underline\
-            \ }}"
+          replace: |-
+            Next\n----\n\n${{ steps.calver.outputs.release }}\n${{ steps.changelog_underline.outputs.underline }}\n
           include: CHANGELOG.rst
           regex: false
 


### PR DESCRIPTION
Use YAML block scalar syntax for replace field to fix zizmor warning.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates the GitHub Actions release workflow to avoid lint warnings and ensure correct multiline replacement formatting.
> 
> - Changes `replace` in `Update changelog` step to a YAML block scalar, inserting the new version header and underline with a trailing newline
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 743151e70f38f182bd8204b347a7edaa15985932. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->