### PR TITLE
Fix block scalar newline interpretation in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,8 +58,7 @@ jobs:
         uses: jacobtomlinson/gha-find-replace@v3
         with:
           find: "Next\n----"
-          replace: |-
-            Next\n----\n\n${{ steps.calver.outputs.release }}\n${{ steps.changelog_underline.outputs.underline }}\n
+          replace: "Next\n----\n\n${{ steps.calver.outputs.release }}\n${{ steps.changelog_underline.outputs.underline }}\n"
           include: CHANGELOG.rst
           regex: false
 


### PR DESCRIPTION
The previous fix used a YAML block scalar (`|-`) which doesn't interpret `\n` as newlines, causing literal `\n` to appear in CHANGELOG.rst. This fix uses a double-quoted string on a single line which correctly interprets escape sequences.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adjusts the release workflow to correctly format the changelog entry.
> 
> - In `.github/workflows/release.yml`, change the `gha-find-replace` `replace` value from a YAML block scalar to a double-quoted string so `\n` escapes produce actual newlines when inserting the new release section under `Next`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9666724d07d928020ea40cde2a5e93a6590ceb04. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->