### PR TITLE
Update sphinxnotes-strike dependency version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ dependencies = [
     "sphinx-simplepdf>=1.6.0",
     "sphinx-toolbox>=4.0.0",
     "sphinxcontrib-video>=0.4.0",
-    "sphinxnotes-strike>=2.0a0",
+    "sphinxnotes-strike>=2.0",
     "ultimate-notion>=0.9.6",
 ]
 optional-dependencies.dev = [


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Updates dependency version requirement to use the stable release.
> 
> - Bumps `sphinxnotes-strike` in `pyproject.toml` from `>=2.0a0` to `>=2.0`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3035a990fa016ffbe5778278e510160cad96b4f0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->