### PR TITLE
Remove now-unnecessary pyright ignore

### DIFF
--- a/src/sphinx_notion/__init__.py
+++ b/src/sphinx_notion/__init__.py
@@ -33,12 +33,7 @@ from sphinx_simplepdf.directives.pdfinclude import (  # pyright: ignore[reportMi
     PdfIncludeDirective,
 )
 from sphinx_toolbox.collapse import CollapseNode
-
-# See https://github.com/sphinx-contrib/video/pull/60.
-from sphinxcontrib.video import (  # pyright: ignore[reportMissingTypeStubs]
-    Video,
-    video_node,
-)
+from sphinxcontrib.video import Video, video_node
 from sphinxnotes.strike import strike_node
 from ultimate_notion import Emoji
 from ultimate_notion.blocks import PDF as UnoPDF  # noqa: N811


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Removes a redundant `pyright` ignore and simplifies the `sphinxcontrib.video` import.
> 
> - Consolidates to `from sphinxcontrib.video import Video, video_node` in `__init__.py` without type-stub ignores; no functional changes expected.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 866b4fcef57d1369c2345ffc5a33e18b80655aeb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->