### PR TITLE
Pin Sphinx to work around https://github.com/sphinx-toolbox/sphinx-to…

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,9 @@ dependencies = [
     "cloup>=3.0.0",
     "docutils>=0.21",
     "requests>=2.32.5",
-    "sphinx>=8.2.3",
+    # Pin Sphinx to <9 to avoid
+    # https://github.com/sphinx-toolbox/sphinx-toolbox/issues/201
+    "sphinx>=8.2.3,<9",
     "sphinx-iframes>=1.1.0",
     "sphinx-immaterial>=0.13.7",
     "sphinx-simplepdf>=1.6.0",


### PR DESCRIPTION
…olbox/issues/201

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Pins Sphinx to a safe range to avoid a known upstream breakage.
> 
> - Constrains `sphinx` to `>=8.2.3,<9` in `pyproject.toml` with an inline comment referencing sphinx-toolbox issue 201
> - No other dependency or code changes
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c68fe2f07283c8cec20660f82aac5f971610defc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->