### PR TITLE
Fix a broken comment

### DIFF
--- a/src/sphinx_notion/__init__.py
+++ b/src/sphinx_notion/__init__.py
@@ -2241,6 +2241,7 @@ def setup(app: Sphinx) -> ExtensionMetadata:
         html=(_visit_mention_date_node_html, None),
     )
 
+    # ``sphinxcontrib.video`` implements a ``video`` directive
     # that we use. The ``sphinx-iframes`` extension implements a ``video``
     # directive that we don't use.
     # Make sure that if they are both enabled, we use the


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Clarifies behavior around the `video` directive selection.
> 
> - Adds a comment noting that, if both `sphinxcontrib.video` and `sphinx-iframes` are enabled, the extension uses `sphinxcontrib.video`'s `video` directive via `app.add_directive(..., override=True)`
> 
> No functional changes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 85cb9cad90da51ff534b1dc17e8ccb15dbd628f8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->