### PR TITLE
Use bash shell for CI steps to ensure early failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,4 @@
 ---
-
 name: Test
 
 on:
@@ -16,7 +15,6 @@ permissions: {}
 
 jobs:
   build:
-
     strategy:
       matrix:
         python-version: ['3.12', '3.13']
@@ -37,14 +35,23 @@ jobs:
           cache-dependency-glob: '**/pyproject.toml'
 
       - name: Build sample
+        # Use bash to ensure the step fails if any command fails.
+        # PowerShell does not fail on intermediate command failures by default.
+        shell: bash
         run: |
           uv run --extra=sample --python=${{ matrix.python-version }} sphinx-build -W -b notion sample/ build-sample/
 
       - name: Run lint
+        # Use bash to ensure the step fails if any command fails.
+        # PowerShell does not fail on intermediate command failures by default.
+        shell: bash
         run: |
           uv run --extra=dev --python=${{ matrix.python-version }} prek run --all-files --hook-stage ${{ matrix.lint-stage }} --verbose
 
       - name: Run tests
+        # Use bash to ensure the step fails if any command fails.
+        # PowerShell does not fail on intermediate command failures by default.
+        shell: bash
         run: |
           # We run tests against "." and not the tests directory as we test the README
           # and documentation.


### PR DESCRIPTION
PowerShell does not fail on intermediate command failures by default. By using bash shell, we ensure that any failing command causes the step to fail immediately.

See https://github.com/adamtheturtle/doccmd/pull/720 for the original learning.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches CI workflow to explicitly run critical steps with `bash` to fail fast on intermediate command errors.
> 
> - In `.github/workflows/ci.yml`, sets `shell: bash` for `Build sample`, `Run lint`, and `Run tests` steps in the matrix `build` job
> - Adds clarifying comments about PowerShell not failing on intermediate command errors by default
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0304b2a3f0e3d3dc3270163a47188834a18f2719. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->