### PR TITLE
Replace docformatter with pydocstringformatter

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ ci:
     - check-manifest
     - deptry
     - doc8
-    - docformatter
+    - pydocstringformatter
     - docs
     - interrogate
     - interrogate-docs
@@ -104,9 +104,9 @@ repos:
         additional_dependencies: [uv==0.9.5]
         stages: [pre-commit]
 
-      - id: docformatter
-        name: docformatter
-        entry: uv run --extra=dev -m docformatter --in-place
+      - id: pydocstringformatter
+        name: pydocstringformatter
+        entry: uv run --extra=dev pydocstringformatter
         language: python
         types_or: [python]
         additional_dependencies: [uv==0.9.5]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,13 +56,13 @@ optional-dependencies.dev = [
     "deptry==0.24.0",
     "doc8==2.0.0",
     "doccmd==2026.1.25",
-    "docformatter==1.7.7",
     "freezegun==1.5.5",
     "furo==2025.12.19",
     "interrogate==1.7.0",
     "mypy[faster-cache]==1.19.1",
     "mypy-strict-kwargs==2026.1.12",
     "prek==0.3.0",
+    "pydocstringformatter==0.7.3",
     "pydocstyle==6.3",
     "pygments==2.19.2",
     "pylint[spelling]==4.0.4",
@@ -136,8 +136,8 @@ lint.select = [
 lint.ignore = [
     # Ruff warns that this conflicts with the formatter.
     "COM812",
-    # Allow our chosen docstring line-style - no one-line summary.
-    "D200",
+    # Allow our chosen docstring line-style - pydocstringformatter handles formatting
+    # but doesn't enforce D205 (blank line after summary) or D212 (summary on first line).
     "D205",
     "D212",
     # Ruff warns that this conflicts with the formatter.
@@ -150,6 +150,9 @@ lint.ignore = [
 ]
 
 lint.per-file-ignores."doccmd_*.py" = [
+    # Allow our chosen docstring line-style - pydocstringformatter handles
+    # formatting but docstrings in docs may not match this style.
+    "D200",
     # Allow asserts in docs.
     "S101",
 ]
@@ -296,9 +299,6 @@ spelling-private-dict-file = 'spelling_private_dict.txt'
 # --spelling-private-dict-file option instead of raising a message.
 spelling-store-unknown-words = 'no'
 
-[tool.docformatter]
-make-summary-multi-line = true
-
 [tool.check-manifest]
 
 ignore = [
@@ -373,6 +373,12 @@ plugins = [
 enableTypeIgnoreComments = false
 reportUnnecessaryTypeIgnoreComment = true
 typeCheckingMode = "strict"
+
+[tool.pydocstringformatter]
+write = true
+split-summary-body = false
+max-line-length = 75
+linewrap-full-docstring = true
 
 [tool.interrogate]
 fail-under = 100

--- a/sample/__init__.py
+++ b/sample/__init__.py
@@ -1,3 +1,1 @@
-"""
-Sample documents to demonstrate Sphinx+Notion functionality.
-"""
+"""Sample documents to demonstrate Sphinx+Notion functionality."""

--- a/sample/conf.py
+++ b/sample/conf.py
@@ -1,6 +1,4 @@
-"""
-Configuration for Sphinx.
-"""
+"""Configuration for Sphinx."""
 
 import sys
 from pathlib import Path

--- a/sample/example_module.py
+++ b/sample/example_module.py
@@ -17,9 +17,7 @@ def greet(*, name: str) -> str:
 
 
 class Calculator:
-    """
-    A simple calculator class for demonstration.
-    """
+    """A simple calculator class for demonstration."""
 
     def __init__(self, *, initial_value: float = 0) -> None:
         """Initialize the calculator.

--- a/src/_notion_scripts/__init__.py
+++ b/src/_notion_scripts/__init__.py
@@ -1,3 +1,1 @@
-"""
-Scripts to interact with Notion.
-"""
+"""Scripts to interact with Notion."""

--- a/src/_notion_scripts/upload.py
+++ b/src/_notion_scripts/upload.py
@@ -37,9 +37,7 @@ def _block_without_children(
     *,
     block: ParentBlock,
 ) -> ParentBlock:
-    """
-    Return a copy of a block without children.
-    """
+    """Return a copy of a block without children."""
     serialized_block = block.obj_ref.serialize_for_api()
     if block.has_children:
         serialized_block[serialized_block["type"]]["children"] = []
@@ -60,9 +58,7 @@ def _block_without_children(
 @beartype
 @cache
 def _calculate_file_sha(*, file_path: Path) -> str:
-    """
-    Calculate SHA-256 hash of a file.
-    """
+    """Calculate SHA-256 hash of a file."""
     sha256_hash = hashlib.sha256()
     with file_path.open(mode="rb") as f:
         for chunk in iter(lambda: f.read(4096), b""):
@@ -73,9 +69,7 @@ def _calculate_file_sha(*, file_path: Path) -> str:
 @beartype
 @cache
 def _calculate_file_sha_from_url(*, file_url: str) -> str:
-    """
-    Calculate SHA-256 hash of a file from a URL.
-    """
+    """Calculate SHA-256 hash of a file from a URL."""
     sha256_hash = hashlib.sha256()
     with requests.get(url=file_url, stream=True, timeout=10) as response:
         response.raise_for_status()
@@ -88,7 +82,8 @@ def _calculate_file_sha_from_url(*, file_url: str) -> str:
 @beartype
 def _files_match(*, existing_file_url: str, local_file_path: Path) -> bool:
     """
-    Check if an existing file matches a local file by comparing SHA-256 hashes.
+    Check if an existing file matches a local file by comparing SHA-256
+    hashes.
     """
     existing_file_sha = _calculate_file_sha_from_url(
         file_url=existing_file_url
@@ -134,9 +129,7 @@ def _is_existing_equivalent(
     existing_page_block: Block,
     local_block: Block,
 ) -> bool:
-    """
-    Check if a local block is equivalent to an existing page block.
-    """
+    """Check if a local block is equivalent to an existing page block."""
     if type(existing_page_block) is not type(local_block):
         return False
 
@@ -201,7 +194,8 @@ def _get_uploaded_cover(
     session: Session,
 ) -> UploadedFile | None:
     """
-    Get uploaded cover file, or None if it matches the existing cover.
+    Get uploaded cover file, or None if it matches the existing
+    cover.
     """
     if (
         page.cover is not None
@@ -224,9 +218,7 @@ def _get_uploaded_cover(
 
 @beartype
 def _block_with_uploaded_file(*, block: Block, session: Session) -> Block:
-    """
-    Replace a file block with an uploaded file block.
-    """
+    """Replace a file block with an uploaded file block."""
     if isinstance(block, _FILE_BLOCK_TYPES):
         parsed = urlparse(url=block.url)
         if parsed.scheme == "file":
@@ -330,9 +322,7 @@ def main(
     cover_url: str | None,
     cancel_on_discussion: bool,
 ) -> None:
-    """
-    Upload documentation to Notion.
-    """
+    """Upload documentation to Notion."""
     session = Session()
 
     blocks = json.loads(s=file.read_text(encoding="utf-8"))

--- a/src/sphinx_notion/__init__.py
+++ b/src/sphinx_notion/__init__.py
@@ -1,6 +1,4 @@
-"""
-Sphinx Notion Builder.
-"""
+"""Sphinx Notion Builder."""
 
 import datetime as dt
 import json
@@ -93,9 +91,7 @@ _LOGGER = sphinx_logging.getLogger(name=__name__)
 
 @beartype
 def _get_text_color_mapping() -> dict[str, Color]:
-    """
-    Get the mapping from CSS classes to Notion colors.
-    """
+    """Get the mapping from CSS classes to Notion colors."""
     return {
         "text-red": Color.RED,
         "text-blue": Color.BLUE,
@@ -112,9 +108,7 @@ def _get_text_color_mapping() -> dict[str, Color]:
 
 @beartype
 def _get_background_color_classes() -> set[str]:
-    """
-    Get the set of supported background color classes.
-    """
+    """Get the set of supported background color classes."""
     return {
         "bg-red",
         "bg-blue",
@@ -178,7 +172,8 @@ def _serialize_block_with_children(
     block: Block,
 ) -> dict[str, Any]:
     """
-    Convert a block to a JSON-serializable format which includes its children.
+    Convert a block to a JSON-serializable format which includes its
+    children.
     """
     serialized_obj = block.obj_ref.serialize_for_api()
     if isinstance(block, ParentBlock) and block.has_children:
@@ -191,21 +186,15 @@ def _serialize_block_with_children(
 
 @beartype
 class _PdfNode(nodes.raw):  # pylint: disable=too-many-ancestors
-    """
-    Custom PDF node for Notion PDF blocks.
-    """
+    """Custom PDF node for Notion PDF blocks."""
 
 
 @beartype
 class _NotionPdfIncludeDirective(PdfIncludeDirective):
-    """
-    PDF include directive that creates Notion PDF blocks.
-    """
+    """PDF include directive that creates Notion PDF blocks."""
 
     def run(self) -> list[nodes.raw]:
-        """
-        Create a Notion PDF block.
-        """
+        """Create a Notion PDF block."""
         (pdf_file,) = self.arguments
         node = _PdfNode()
         node.attributes["uri"] = pdf_file
@@ -214,51 +203,37 @@ class _NotionPdfIncludeDirective(PdfIncludeDirective):
 
 @beartype
 class _LinkToPageNode(nodes.Element):
-    """
-    Custom node for Notion link-to-page blocks.
-    """
+    """Custom node for Notion link-to-page blocks."""
 
 
 @beartype
 class _MentionUserNode(nodes.Inline, nodes.TextElement):
-    """
-    Custom node for Notion user mentions.
-    """
+    """Custom node for Notion user mentions."""
 
 
 @beartype
 class _MentionPageNode(nodes.Inline, nodes.TextElement):
-    """
-    Custom node for Notion page mentions.
-    """
+    """Custom node for Notion page mentions."""
 
 
 @beartype
 class _MentionDatabaseNode(nodes.Inline, nodes.TextElement):
-    """
-    Custom node for Notion database mentions.
-    """
+    """Custom node for Notion database mentions."""
 
 
 @beartype
 class _MentionDateNode(nodes.Inline, nodes.TextElement):
-    """
-    Custom node for Notion date mentions.
-    """
+    """Custom node for Notion date mentions."""
 
 
 @beartype
 class _NotionLinkToPageDirective(sphinx_docutils.SphinxDirective):
-    """
-    Link-to-page directive that creates Notion link-to-page blocks.
-    """
+    """Link-to-page directive that creates Notion link-to-page blocks."""
 
     required_arguments = 1
 
     def run(self) -> list[nodes.Element]:
-        """
-        Create a Notion link-to-page block.
-        """
+        """Create a Notion link-to-page block."""
         (page_id,) = self.arguments
         page_uuid = UUID(hex=page_id)
 
@@ -285,9 +260,7 @@ def _notion_mention_user_role(  # pylint: disable=too-many-positional-arguments
     options: dict[str, Any] | None = None,
     content: Sequence[str] = (),
 ) -> tuple[list[nodes.Node], list[nodes.system_message]]:
-    """
-    Create a Notion user mention role.
-    """
+    """Create a Notion user mention role."""
     del name, rawtext, lineno, inliner, options, content
     user_uuid = UUID(hex=text_content)
     node = _MentionUserNode()
@@ -306,9 +279,7 @@ def _notion_mention_page_role(  # pylint: disable=too-many-positional-arguments
     options: dict[str, Any] | None = None,
     content: Sequence[str] = (),
 ) -> tuple[list[nodes.Node], list[nodes.system_message]]:
-    """
-    Create a Notion page mention role.
-    """
+    """Create a Notion page mention role."""
     del name, rawtext, lineno, inliner, options, content
     page_uuid = UUID(hex=text_content)
     node = _MentionPageNode()
@@ -327,9 +298,7 @@ def _notion_mention_database_role(  # pylint: disable=too-many-positional-argume
     options: dict[str, Any] | None = None,
     content: Sequence[str] = (),
 ) -> tuple[list[nodes.Node], list[nodes.system_message]]:
-    """
-    Create a Notion database mention role.
-    """
+    """Create a Notion database mention role."""
     del name, rawtext, lineno, inliner, options, content
     database_uuid = UUID(hex=text_content)
     node = _MentionDatabaseNode()
@@ -348,9 +317,7 @@ def _notion_mention_date_role(  # pylint: disable=too-many-positional-arguments
     options: dict[str, Any] | None = None,
     content: Sequence[str] = (),
 ) -> tuple[list[nodes.Node], list[nodes.system_message]]:
-    """
-    Create a Notion date mention role.
-    """
+    """Create a Notion date mention role."""
     del name, rawtext, lineno, inliner, options, content
     date_obj = dt.date.fromisoformat(text_content)
     node = _MentionDateNode()
@@ -361,9 +328,7 @@ def _notion_mention_date_role(  # pylint: disable=too-many-positional-arguments
 
 @dataclass
 class _TableStructure:
-    """
-    Structure information extracted from a table node.
-    """
+    """Structure information extracted from a table node."""
 
     header_rows: list[nodes.row]
     body_rows: list[nodes.row]
@@ -391,9 +356,7 @@ def _process_rich_text_node(node: nodes.Node) -> Text:
 @beartype
 @_process_rich_text_node.register
 def _(node: nodes.line) -> Text:
-    """
-    Process line nodes by creating rich text.
-    """
+    """Process line nodes by creating rich text."""
     return _create_styled_text_from_node(node=node) + "\n"
 
 
@@ -433,7 +396,8 @@ def _(node: nodes.reference) -> Text:
 @_process_rich_text_node.register
 def _(node: nodes.target) -> Text:
     """
-    Process target nodes by returning empty text (targets are skipped).
+    Process target nodes by returning empty text (targets are
+    skipped).
     """
     del node  # Target nodes are skipped
     return Text.from_plain_text(text="")
@@ -453,81 +417,63 @@ def _(node: nodes.title_reference) -> Text:
 @beartype
 @_process_rich_text_node.register
 def _(node: nodes.Text) -> Text:
-    """
-    Process Text nodes by creating plain text.
-    """
+    """Process Text nodes by creating plain text."""
     return text(text=node.astext())
 
 
 @beartype
 @_process_rich_text_node.register
 def _(node: nodes.inline) -> Text:
-    """
-    Process inline nodes by creating styled text.
-    """
+    """Process inline nodes by creating styled text."""
     return _create_styled_text_from_node(node=node)
 
 
 @beartype
 @_process_rich_text_node.register
 def _(node: nodes.strong) -> Text:
-    """
-    Process strong nodes by creating bold text.
-    """
+    """Process strong nodes by creating bold text."""
     return _create_styled_text_from_node(node=node)
 
 
 @beartype
 @_process_rich_text_node.register
 def _(node: nodes.emphasis) -> Text:
-    """
-    Process emphasis nodes by creating italic text.
-    """
+    """Process emphasis nodes by creating italic text."""
     return _create_styled_text_from_node(node=node)
 
 
 @beartype
 @_process_rich_text_node.register
 def _(node: nodes.literal) -> Text:
-    """
-    Process literal nodes by creating code text.
-    """
+    """Process literal nodes by creating code text."""
     return _create_styled_text_from_node(node=node)
 
 
 @beartype
 @_process_rich_text_node.register
 def _(node: strike_node) -> Text:
-    """
-    Process strike nodes by creating strikethrough text.
-    """
+    """Process strike nodes by creating strikethrough text."""
     return _create_styled_text_from_node(node=node)
 
 
 @beartype
 @_process_rich_text_node.register
 def _(node: nodes.paragraph) -> Text:
-    """
-    Process paragraph nodes by creating styled text.
-    """
+    """Process paragraph nodes by creating styled text."""
     return _create_styled_text_from_node(node=node)
 
 
 @beartype
 @_process_rich_text_node.register
 def _(node: nodes.math) -> Text:
-    """
-    Process math nodes by creating math rich text.
-    """
+    """Process math nodes by creating math rich text."""
     return math(expression=node.astext())
 
 
 @beartype
 @_process_rich_text_node.register
 def _(node: _MentionUserNode) -> Text:
-    """
-    Process mention user nodes by creating user mention rich text.
-    """
+    """Process mention user nodes by creating user mention rich text."""
     user_id = node.attributes["user_id"]
     user_ref = UserRef(id=user_id)
     mention_obj = MentionUser.build_mention_from(
@@ -540,9 +486,7 @@ def _(node: _MentionUserNode) -> Text:
 @beartype
 @_process_rich_text_node.register
 def _(node: _MentionPageNode) -> Text:
-    """
-    Process mention page nodes by creating page mention rich text.
-    """
+    """Process mention page nodes by creating page mention rich text."""
     page_id = node.attributes["page_id"]
     page_obj_ref = ObjectRef(id=page_id)
     mention_obj = MentionPage.build_mention_from(
@@ -556,7 +500,8 @@ def _(node: _MentionPageNode) -> Text:
 @_process_rich_text_node.register
 def _(node: _MentionDatabaseNode) -> Text:
     """
-    Process mention database nodes by creating database mention rich text.
+    Process mention database nodes by creating database mention rich
+    text.
     """
     database_id = node.attributes["database_id"]
     database_obj_ref = ObjectRef(id=database_id)
@@ -570,9 +515,7 @@ def _(node: _MentionDatabaseNode) -> Text:
 @beartype
 @_process_rich_text_node.register
 def _(node: _MentionDateNode) -> Text:
-    """
-    Process mention date nodes by creating date mention rich text.
-    """
+    """Process mention date nodes by creating date mention rich text."""
     parsed_date = node.attributes["date"]
     date_range = DateRange.build(dt_spec=parsed_date)
 
@@ -679,9 +622,7 @@ def _extract_table_structure(
     *,
     node: nodes.table,
 ) -> _TableStructure:
-    """
-    Return table structure information for a table node.
-    """
+    """Return table structure information for a table node."""
     header_rows: list[nodes.row] = []
     body_rows: list[nodes.row] = []
     stub_columns = 0
@@ -894,9 +835,7 @@ def _process_node_to_blocks(
     *,
     section_level: int,
 ) -> list[Block]:
-    """
-    Required function for ``singledispatch``.
-    """
+    """Required function for ``singledispatch``."""
     del section_level
     line_number = node.line or node.parent.line
     source = node.source or node.parent.source
@@ -1022,9 +961,7 @@ def _(
     *,
     section_level: int,
 ) -> list[Block]:
-    """
-    Process block quote nodes by creating Notion Quote blocks.
-    """
+    """Process block quote nodes by creating Notion Quote blocks."""
     first_child = node.children[0]
     rich_text = _process_rich_text_node(first_child)
     quote = UnoQuote(text=rich_text)
@@ -1042,9 +979,7 @@ def _(
     *,
     section_level: int,
 ) -> list[Block]:
-    """
-    Process literal block nodes by creating Notion Code blocks.
-    """
+    """Process literal block nodes by creating Notion Code blocks."""
     del section_level
     code_text = _create_rich_text_from_children(node=node)
     language = _get_code_language(node=node)
@@ -1059,7 +994,8 @@ def _(
     section_level: int,
 ) -> list[Block]:
     """
-    Process bullet list nodes by creating Notion BulletedItem blocks.
+    Process bullet list nodes by creating Notion BulletedItem
+    blocks.
     """
     result: list[Block] = []
     for list_item in node.children:
@@ -1109,7 +1045,8 @@ def _(
     section_level: int,
 ) -> list[Block]:
     """
-    Process enumerated list nodes by creating Notion NumberedItem or ToDoItem
+    Process enumerated list nodes by creating Notion NumberedItem or
+    ToDoItem
     blocks.
     """
     result: list[Block] = []
@@ -1174,7 +1111,8 @@ def _(
     *,
     section_level: int,
 ) -> list[Block]:
-    """Process definition list nodes by creating Notion BulletedItem blocks.
+    """Process definition list nodes by creating Notion BulletedItem
+    blocks.
 
     Each definition list item becomes a bulleted item with the term and
     definition content as nested blocks. Classifiers (if present) are
@@ -1221,9 +1159,7 @@ def _(
     *,
     section_level: int,
 ) -> list[Block]:
-    """
-    Process topic nodes, specifically for table of contents.
-    """
+    """Process topic nodes, specifically for table of contents."""
     del section_level  # Not used for topics
     # Later, we can support `.. topic::` directives, likely as
     # a callout with no icon.
@@ -1238,9 +1174,7 @@ def _(
     *,
     section_level: int,
 ) -> list[Block]:
-    """
-    Process Sphinx ``toctree`` nodes.
-    """
+    """Process Sphinx ``toctree`` nodes."""
     del node
     del section_level
     # There are no specific Notion blocks for ``toctree`` nodes.
@@ -1257,7 +1191,8 @@ def _(
     section_level: int,
 ) -> list[Block]:
     """
-    Process title nodes by creating appropriate Notion heading blocks.
+    Process title nodes by creating appropriate Notion heading
+    blocks.
     """
     rich_text = _create_rich_text_from_children(node=node)
 
@@ -1326,9 +1261,7 @@ def _(
     *,
     section_level: int,
 ) -> list[Block]:
-    """
-    Process note admonition nodes by creating Notion Callout blocks.
-    """
+    """Process note admonition nodes by creating Notion Callout blocks."""
     del section_level
     return _create_admonition_callout(
         node=node,
@@ -1345,7 +1278,8 @@ def _(
     section_level: int,
 ) -> list[Block]:
     """
-    Process warning admonition nodes by creating Notion Callout blocks.
+    Process warning admonition nodes by creating Notion Callout
+    blocks.
     """
     del section_level
     return _create_admonition_callout(
@@ -1362,9 +1296,7 @@ def _(
     *,
     section_level: int,
 ) -> list[Block]:
-    """
-    Process tip admonition nodes by creating Notion Callout blocks.
-    """
+    """Process tip admonition nodes by creating Notion Callout blocks."""
     del section_level
     return _create_admonition_callout(
         node=node,
@@ -1381,7 +1313,8 @@ def _(
     section_level: int,
 ) -> list[Block]:
     """
-    Process attention admonition nodes by creating Notion Callout blocks.
+    Process attention admonition nodes by creating Notion Callout
+    blocks.
     """
     del section_level
     return _create_admonition_callout(
@@ -1399,7 +1332,8 @@ def _(
     section_level: int,
 ) -> list[Block]:
     """
-    Process caution admonition nodes by creating Notion Callout blocks.
+    Process caution admonition nodes by creating Notion Callout
+    blocks.
     """
     del section_level
     return _create_admonition_callout(
@@ -1417,7 +1351,8 @@ def _(
     section_level: int,
 ) -> list[Block]:
     """
-    Process danger admonition nodes by creating Notion Callout blocks.
+    Process danger admonition nodes by creating Notion Callout
+    blocks.
     """
     del section_level
     return _create_admonition_callout(
@@ -1435,7 +1370,8 @@ def _(
     section_level: int,
 ) -> list[Block]:
     """
-    Process error admonition nodes by creating Notion Callout blocks.
+    Process error admonition nodes by creating Notion Callout
+    blocks.
     """
     del section_level
     return _create_admonition_callout(
@@ -1452,9 +1388,7 @@ def _(
     *,
     section_level: int,
 ) -> list[Block]:
-    """
-    Process hint admonition nodes by creating Notion Callout blocks.
-    """
+    """Process hint admonition nodes by creating Notion Callout blocks."""
     del section_level
     return _create_admonition_callout(
         node=node,
@@ -1471,7 +1405,8 @@ def _(
     section_level: int,
 ) -> list[Block]:
     """
-    Process important admonition nodes by creating Notion Callout blocks.
+    Process important admonition nodes by creating Notion Callout
+    blocks.
     """
     del section_level
     return _create_admonition_callout(
@@ -1528,9 +1463,7 @@ def _(
     *,
     section_level: int,
 ) -> list[Block]:
-    """
-    Process collapse nodes by creating Notion ToggleItem blocks.
-    """
+    """Process collapse nodes by creating Notion ToggleItem blocks."""
     del section_level
 
     title_text = node.attributes["label"]
@@ -1554,9 +1487,7 @@ def _(
     *,
     section_level: int,
 ) -> list[Block]:
-    """
-    Process image nodes by creating Notion Image blocks.
-    """
+    """Process image nodes by creating Notion Image blocks."""
     del section_level
 
     image_url = node.attributes["uri"]
@@ -1577,9 +1508,7 @@ def _(
     *,
     section_level: int,
 ) -> list[Block]:
-    """
-    Process video nodes by creating Notion Video blocks.
-    """
+    """Process video nodes by creating Notion Video blocks."""
     del section_level
 
     sources: list[tuple[str, str, bool]] = node.attributes["sources"]
@@ -1612,9 +1541,7 @@ def _(
     *,
     section_level: int,
 ) -> list[Block]:
-    """
-    Process audio nodes by creating Notion Audio blocks.
-    """
+    """Process audio nodes by creating Notion Audio blocks."""
     del section_level
 
     audio_url = node.attributes["uri"]
@@ -1677,9 +1604,7 @@ def _(
     *,
     section_level: int,
 ) -> list[Block]:
-    """
-    Process container nodes.
-    """
+    """Process container nodes."""
     num_children_for_captioned_literalinclude = 2
     if (
         len(node.children) == num_children_for_captioned_literalinclude
@@ -1726,7 +1651,8 @@ def _(
     section_level: int,
 ) -> list[Block]:
     """
-    Process raw nodes, specifically those containing HTML from the extension
+    Process raw nodes, specifically those containing HTML from the
+    extension
     ``sphinx-iframes``.
     """
     del section_level
@@ -1749,7 +1675,8 @@ def _process_rest_example_container(
     section_level: int,
 ) -> list[Block]:
     """
-    Process a ``rest-example`` container by creating nested callout blocks.
+    Process a ``rest-example`` container by creating nested callout
+    blocks.
     """
     rst_source_node = node.children[0]
     assert isinstance(rst_source_node, nodes.literal_block)
@@ -1797,9 +1724,7 @@ def _(
     *,
     section_level: int,
 ) -> list[Block]:
-    """
-    Process math block nodes by creating Notion Equation blocks.
-    """
+    """Process math block nodes by creating Notion Equation blocks."""
     del section_level
     latex_content = node.astext()
     return [UnoEquation(latex=latex_content)]
@@ -1833,9 +1758,7 @@ def _(
     *,
     section_level: int,
 ) -> list[Block]:
-    """
-    Process target nodes by ignoring them completely.
-    """
+    """Process target nodes by ignoring them completely."""
     del node
     del section_level
     return []
@@ -1848,9 +1771,7 @@ def _(
     *,
     section_level: int,
 ) -> list[Block]:
-    """
-    Process document nodes by ignoring them completely.
-    """
+    """Process document nodes by ignoring them completely."""
     del node
     del section_level
     return []
@@ -1864,7 +1785,8 @@ def _(
     section_level: int,
 ) -> list[Block]:
     """
-    Process line block nodes by creating separate paragraph blocks for each
+    Process line block nodes by creating separate paragraph blocks for
+    each
     line.
     """
     del section_level
@@ -1880,9 +1802,7 @@ def _(
     *,
     section_level: int,
 ) -> list[Block]:
-    """
-    Process transition nodes by creating Notion Divider blocks.
-    """
+    """Process transition nodes by creating Notion Divider blocks."""
     del node
     del section_level
     return [UnoDivider()]
@@ -1987,14 +1907,10 @@ def _(
 
 @beartype
 class NotionTranslator(NodeVisitor):
-    """
-    Translate ``docutils`` nodes to Notion JSON.
-    """
+    """Translate ``docutils`` nodes to Notion JSON."""
 
     def __init__(self, document: nodes.document, builder: TextBuilder) -> None:
-        """
-        Initialize the translator with storage for blocks.
-        """
+        """Initialize the translator with storage for blocks."""
         del builder
         super().__init__(document=document)
         self._blocks: list[Block] = []
@@ -2002,9 +1918,7 @@ class NotionTranslator(NodeVisitor):
         self._section_level = 0
 
     def dispatch_visit(self, node: nodes.Node) -> None:
-        """
-        Handle nodes by creating appropriate Notion heading blocks.
-        """
+        """Handle nodes by creating appropriate Notion heading blocks."""
         if isinstance(node, nodes.section):
             self._section_level += 1
             return
@@ -2019,15 +1933,14 @@ class NotionTranslator(NodeVisitor):
 
     def depart_section(self, node: nodes.Element) -> None:
         """
-        Handle leaving section nodes by decreasing the section level.
+        Handle leaving section nodes by decreasing the section
+        level.
         """
         del node
         self._section_level -= 1
 
     def depart_document(self, node: nodes.Element) -> None:
-        """
-        Output collected block tree as JSON at document end.
-        """
+        """Output collected block tree as JSON at document end."""
         del node
 
         json_output = json.dumps(
@@ -2043,9 +1956,7 @@ class NotionTranslator(NodeVisitor):
 
 @beartype
 class NotionBuilder(TextBuilder):
-    """
-    Build Notion-compatible documents.
-    """
+    """Build Notion-compatible documents."""
 
     name = "notion"
     out_suffix = ".json"
@@ -2055,9 +1966,7 @@ class NotionBuilder(TextBuilder):
 def _notion_register_pdf_include_directive(
     app: Sphinx,
 ) -> None:
-    """
-    Register the PDF include directive.
-    """
+    """Register the PDF include directive."""
     if isinstance(app.builder, NotionBuilder):
         sphinx_docutils.register_directive(
             name="pdf-include",
@@ -2069,9 +1978,7 @@ def _notion_register_pdf_include_directive(
 def _notion_register_link_to_page_directive(
     app: Sphinx,
 ) -> None:
-    """
-    Register the link-to-page directive.
-    """
+    """Register the link-to-page directive."""
     del app
     sphinx_docutils.register_directive(
         name="notion-link-to-page",
@@ -2083,9 +1990,7 @@ def _notion_register_link_to_page_directive(
 def _notion_register_mention_roles(
     app: Sphinx,
 ) -> None:
-    """
-    Register the mention roles.
-    """
+    """Register the mention roles."""
     del app
     sphinx_docutils.register_role(
         name="notion-mention-user",
@@ -2107,23 +2012,17 @@ def _notion_register_mention_roles(
 
 @beartype
 def _visit_strike_node(_: NotionTranslator, __: strike_node) -> None:
-    """
-    Dummy visitor for strike nodes.
-    """
+    """Dummy visitor for strike nodes."""
 
 
 @beartype
 def _depart_strike_node(_: NotionTranslator, __: strike_node) -> None:
-    """
-    Dummy depart for strike nodes.
-    """
+    """Dummy depart for strike nodes."""
 
 
 @beartype
 def _register_strike_node_handlers(app: Sphinx, __: Config) -> None:
-    """
-    Register strike_node handlers for the notion builder.
-    """
+    """Register strike_node handlers for the notion builder."""
     app.add_node(
         node=strike_node,
         override=True,
@@ -2134,7 +2033,8 @@ def _register_strike_node_handlers(app: Sphinx, __: Config) -> None:
 @beartype
 def _make_static_dir(app: Sphinx) -> None:
     """
-    We make the ``_static`` directory that ``sphinx-iframes`` expects.
+    We make the ``_static`` directory that ``sphinx-iframes``
+    expects.
     """
     (app.outdir / "_static").mkdir(parents=True, exist_ok=True)
 
@@ -2199,9 +2099,7 @@ def _visit_mention_date_node_html(
 
 @beartype
 def setup(app: Sphinx) -> ExtensionMetadata:
-    """
-    Add the builder to Sphinx.
-    """
+    """Add the builder to Sphinx."""
     app.add_builder(builder=NotionBuilder)
     app.set_translator(name="notion", translator_class=NotionTranslator)
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,3 +1,1 @@
-"""
-Tests for Sphinx Notion Builder.
-"""
+"""Tests for Sphinx Notion Builder."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,4 @@
-"""
-Configuration for ``pytest``.
-"""
+"""Configuration for ``pytest``."""
 
 import pytest
 from beartype import beartype
@@ -10,7 +8,8 @@ pytest_plugins = "sphinx.testing.fixtures"  # pylint: disable=invalid-name
 
 def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
     """
-    Apply the ``beartype`` decorator to all collected test functions.
+    Apply the ``beartype`` decorator to all collected test
+    functions.
     """
     for item in items:
         # All our tests are functions, for now

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -1,6 +1,4 @@
-"""
-Tests for the Sphinx builder.
-"""
+"""Tests for the Sphinx builder."""
 
 from collections.abc import Callable
 from importlib.metadata import version
@@ -18,7 +16,8 @@ def test_meta(
     tmp_path: Path,
 ) -> None:
     """
-    Builder metadata and setup returns expected values for Sphinx integration.
+    Builder metadata and setup returns expected values for Sphinx
+    integration.
     """
     builder_cls = sphinx_notion.NotionBuilder
     assert builder_cls.name == "notion"

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,6 +1,4 @@
-"""
-Integration tests for the Sphinx Notion Builder functionality.
-"""
+"""Integration tests for the Sphinx Notion Builder functionality."""
 
 import base64
 import datetime as dt
@@ -71,9 +69,7 @@ from ultimate_notion.rich_text import Text, math, text
 
 @beartype
 def _details_from_block(*, block: Block) -> dict[str, Any]:
-    """
-    Create a serialized block details from a Block.
-    """
+    """Create a serialized block details from a Block."""
     serialized_obj = block.obj_ref.serialize_for_api()
     if isinstance(block, ParentBlock) and block.has_children:
         serialized_obj[block.obj_ref.type]["children"] = [
@@ -95,7 +91,8 @@ def _assert_rst_converts_to_notion_objects(
     confoverrides: dict[str, Any] | None = None,
 ) -> SphinxTestApp:
     """
-    ReStructuredText content converts to expected Notion objects via Sphinx
+    ReStructuredText content converts to expected Notion objects via
+    Sphinx
     build process.
     """
     confoverrides = confoverrides or {}
@@ -143,9 +140,7 @@ def test_single_paragraph(
     make_app: Callable[..., SphinxTestApp],
     tmp_path: Path,
 ) -> None:
-    """
-    Single paragraph becomes Notion paragraph block.
-    """
+    """Single paragraph becomes Notion paragraph block."""
     rst_content = """
         This is a simple paragraph for testing.
     """
@@ -168,7 +163,8 @@ def test_rubric(
     tmp_path: Path,
 ) -> None:
     """
-    Rubric directive becomes bold paragraph (informal heading not in any table
+    Rubric directive becomes bold paragraph (informal heading not in any
+    table
     of contents).
     """
     rst_content = """
@@ -204,7 +200,8 @@ def test_rubric_with_inline_formatting(
     tmp_path: Path,
 ) -> None:
     """
-    Rubric with inline formatting preserves bold, italic, and code styles.
+    Rubric with inline formatting preserves bold, italic, and code
+    styles.
     """
     rst_content = """
         .. rubric:: A rubric with ``code`` and *italic*
@@ -235,7 +232,8 @@ def test_notion_link_to_page(
     tmp_path: Path,
 ) -> None:
     """
-    ``notion-link-to-page`` directives become Notion link-to-page blocks.
+    ``notion-link-to-page`` directives become Notion link-to-page
+    blocks.
     """
     test_page_id = "12345678-1234-1234-1234-123456789abc"
 
@@ -263,7 +261,8 @@ def test_notion_link_to_page_with_content_around(
     tmp_path: Path,
 ) -> None:
     """
-    ``notion-link-to-page`` directive works with surrounding content.
+    ``notion-link-to-page`` directive works with surrounding
+    content.
     """
     test_page_id = "87654321-4321-4321-4321-cba987654321"
 
@@ -297,7 +296,8 @@ def test_notion_link_to_page_html_output(
     tmp_path: Path,
 ) -> None:
     """
-    ``notion-link-to-page`` directive with HTML builder creates a link.
+    ``notion-link-to-page`` directive with HTML builder creates a
+    link.
     """
     test_page_id = "12345678-1234-1234-1234-123456789abc"
     rst_content = f"""
@@ -325,9 +325,7 @@ def test_multiple_paragraphs(
     make_app: Callable[..., SphinxTestApp],
     tmp_path: Path,
 ) -> None:
-    """
-    Multiple paragraphs become separate Notion paragraph blocks.
-    """
+    """Multiple paragraphs become separate Notion paragraph blocks."""
     rst_content = """
         First paragraph with some text.
 
@@ -360,7 +358,8 @@ def test_inline_formatting(
     tmp_path: Path,
 ) -> None:
     """
-    Inline formatting (bold, italic, code) becomes rich text annotations.
+    Inline formatting (bold, italic, code) becomes rich text
+    annotations.
     """
     rst_content = """
         This is **bold** and *italic* and ``inline code``.
@@ -401,9 +400,7 @@ def test_single_heading(
     make_app: Callable[..., SphinxTestApp],
     tmp_path: Path,
 ) -> None:
-    """
-    Single heading becomes Heading 1 block.
-    """
+    """Single heading becomes Heading 1 block."""
     rst_content = """
         Main Title
         ==========
@@ -427,7 +424,8 @@ def test_multiple_heading_levels(
     tmp_path: Path,
 ) -> None:
     """
-    Multiple heading levels become appropriate Notion heading blocks.
+    Multiple heading levels become appropriate Notion heading
+    blocks.
     """
     rst_content = """
         Main Title
@@ -469,7 +467,8 @@ def test_heading_with_formatting(
     tmp_path: Path,
 ) -> None:
     """
-    Headings with inline formatting become rich text in heading blocks.
+    Headings with inline formatting become rich text in heading
+    blocks.
     """
     rst_content = """
         **Bold** and *Italic* Title
@@ -502,9 +501,7 @@ def test_simple_link(
     make_app: Callable[..., SphinxTestApp],
     tmp_path: Path,
 ) -> None:
-    """
-    Simple links become rich text with href attributes.
-    """
+    """Simple links become rich text with href attributes."""
     rst_content = """
         This paragraph contains a `link to example <https://example.com>`_.
     """
@@ -533,7 +530,8 @@ def test_multiple_links(
     tmp_path: Path,
 ) -> None:
     """
-    Multiple links in a paragraph become separate rich text segments.
+    Multiple links in a paragraph become separate rich text
+    segments.
     """
     # Write proper rST content to file to avoid Python string escaping issues
     rst_file = tmp_path / "test_content.rst"
@@ -570,9 +568,7 @@ def test_link_in_heading(
     make_app: Callable[..., SphinxTestApp],
     tmp_path: Path,
 ) -> None:
-    """
-    Links in headings become rich text with href attributes.
-    """
+    """Links in headings become rich text with href attributes."""
     rst_content = """
         Check out `Notion API <https://developers.notion.com>`_
         ========================================================
@@ -602,9 +598,7 @@ def test_mixed_formatting_with_links(
     make_app: Callable[..., SphinxTestApp],
     tmp_path: Path,
 ) -> None:
-    """
-    Links mixed with other formatting preserve all annotations.
-    """
+    """Links mixed with other formatting preserve all annotations."""
     rst_content = """
         This has **bold** and a `link <https://example.com>`_ and *italic*.
     """
@@ -644,7 +638,8 @@ def test_unnamed_link_with_backticks(
     make_app: Callable[..., SphinxTestApp],
     tmp_path: Path,
 ) -> None:
-    """Unnamed links with backticks become rich text with URL as display text.
+    """Unnamed links with backticks become rich text with URL as display
+    text.
 
     The display text excludes angle brackets from the URL.
     """
@@ -675,9 +670,7 @@ def test_simple_quote(
     make_app: Callable[..., SphinxTestApp],
     tmp_path: Path,
 ) -> None:
-    """
-    Block quotes become Notion Quote blocks.
-    """
+    """Block quotes become Notion Quote blocks."""
     rst_content = """
         Some content.
 
@@ -701,7 +694,8 @@ def test_multiline_quote(
     tmp_path: Path,
 ) -> None:
     """
-    Multi-line block quotes become single Notion Quote blocks with line breaks.
+    Multi-line block quotes become single Notion Quote blocks with line
+    breaks.
     """
     rst_content = """
         Some content.
@@ -732,7 +726,8 @@ def test_multi_paragraph_quote(
     tmp_path: Path,
 ) -> None:
     """
-    Block quotes with multiple paragraphs create Quote blocks with nested
+    Block quotes with multiple paragraphs create Quote blocks with
+    nested
     paragraph children.
     """
     rst_content = """
@@ -781,9 +776,7 @@ def test_table_of_contents(
     make_app: Callable[..., SphinxTestApp],
     tmp_path: Path,
 ) -> None:
-    """
-    ``contents`` directive becomes Notion TableOfContents block.
-    """
+    """``contents`` directive becomes Notion TableOfContents block."""
     rst_content = """
         Introduction
         ============
@@ -816,7 +809,8 @@ def test_toctree_directive(
     tmp_path: Path,
 ) -> None:
     """
-    ``toctree`` directive produces no output as it's for navigation structure.
+    ``toctree`` directive produces no output as it's for navigation
+    structure.
     """
     rst_content = """
         Introduction
@@ -842,9 +836,7 @@ def test_simple_code_block(
     make_app: Callable[..., SphinxTestApp],
     tmp_path: Path,
 ) -> None:
-    """
-    Code blocks become Notion Code blocks with syntax highlighting.
-    """
+    """Code blocks become Notion Code blocks with syntax highlighting."""
     rst_content = """
         .. code-block:: python
 
@@ -910,7 +902,8 @@ def test_code_block_unknown_language_suppressed(
     make_app: Callable[..., SphinxTestApp],
     tmp_path: Path,
 ) -> None:
-    """The unknown language warning can be suppressed via suppress_warnings.
+    """The unknown language warning can be suppressed via
+    suppress_warnings.
 
     This verifies that the warning uses the correct type='misc' and
     subtype='highlighting_failure' parameters, not just text that looks
@@ -987,7 +980,8 @@ def test_code_block_language_mapping(
     tmp_path: Path,
 ) -> None:
     """
-    Various languages map to appropriate Notion code block languages.
+    Various languages map to appropriate Notion code block
+    languages.
     """
     rst_content = """
         .. code-block:: console
@@ -1040,9 +1034,7 @@ def test_flat_bullet_list(
     make_app: Callable[..., SphinxTestApp],
     tmp_path: Path,
 ) -> None:
-    """
-    Flat bullet lists become separate Notion BulletedItem blocks.
-    """
+    """Flat bullet lists become separate Notion BulletedItem blocks."""
     rst_content = """
         * First bullet point
         * Second bullet point
@@ -1066,9 +1058,7 @@ def test_bullet_list_with_inline_formatting(
     make_app: Callable[..., SphinxTestApp],
     tmp_path: Path,
 ) -> None:
-    """
-    Bullet lists preserve inline formatting in rich text.
-    """
+    """Bullet lists preserve inline formatting in rich text."""
     rst_content = """
         * This is **bold text** in a bullet
     """
@@ -1116,7 +1106,8 @@ def test_admonition_single_line(
     tmp_path: Path,
 ) -> None:
     """
-    Admonitions become Notion Callout blocks with appropriate icons and colors.
+    Admonitions become Notion Callout blocks with appropriate icons and
+    colors.
     """
     rst_content = f"""
         .. {admonition_type}:: {message}
@@ -1196,9 +1187,7 @@ def test_admonition_with_code_block(
     make_app: Callable[..., SphinxTestApp],
     tmp_path: Path,
 ) -> None:
-    """
-    Admonitions contain code blocks as nested children.
-    """
+    """Admonitions contain code blocks as nested children."""
     rst_content = """
         .. note::
            This note contains a code example.
@@ -1244,7 +1233,8 @@ def test_admonition_with_code_block_first(
     make_app: Callable[..., SphinxTestApp],
     tmp_path: Path,
 ) -> None:
-    """Admonition with code block as first child creates empty callout text.
+    """Admonition with code block as first child creates empty callout
+    text.
 
     When the first child is not a paragraph, the callout text remains
     empty.
@@ -1292,7 +1282,8 @@ def test_admonition_with_bullet_points(
     tmp_path: Path,
 ) -> None:
     """
-    Bullet points appear within admonitions as nested blocks (issue #78).
+    Bullet points appear within admonitions as nested blocks (issue
+    #78).
     """
     rst_content = """
         .. note::
@@ -1337,7 +1328,8 @@ def test_definition_list(
     tmp_path: Path,
 ) -> None:
     """
-    Definition lists become bulleted lists with terms and nested definitions.
+    Definition lists become bulleted lists with terms and nested
+    definitions.
     """
     rst_content = """
         Term 1
@@ -1379,9 +1371,7 @@ def test_definition_list_multiline(
     make_app: Callable[..., SphinxTestApp],
     tmp_path: Path,
 ) -> None:
-    """
-    Definition lists with multiple paragraphs in definitions.
-    """
+    """Definition lists with multiple paragraphs in definitions."""
     rst_content = """
         Term
            First paragraph of definition.
@@ -1419,7 +1409,8 @@ def test_definition_list_with_inline_formatting(
     tmp_path: Path,
 ) -> None:
     """
-    Definition list terms preserve inline formatting like code and emphasis.
+    Definition list terms preserve inline formatting like code and
+    emphasis.
     """
     rst_content = """
         ``code_term``
@@ -1465,7 +1456,8 @@ def test_definition_list_with_classifier(
     tmp_path: Path,
 ) -> None:
     """
-    Definition lists with classifiers append italic classifiers to the term.
+    Definition lists with classifiers append italic classifiers to the
+    term.
     """
     rst_content = """
         term : classifier
@@ -1497,7 +1489,8 @@ def test_generic_admonition(
     make_app: Callable[..., SphinxTestApp],
     tmp_path: Path,
 ) -> None:
-    """Generic admonitions set callout text to the first line of the callout.
+    """Generic admonitions set callout text to the first line of the
+    callout.
 
     Generic admonitions require a title so are different from other
     admonitions.
@@ -1543,9 +1536,7 @@ def test_nested_bullet_list(
     make_app: Callable[..., SphinxTestApp],
     tmp_path: Path,
 ) -> None:
-    """
-    Deeply nested bullet lists create hierarchical block structures.
-    """
+    """Deeply nested bullet lists create hierarchical block structures."""
     rst_content = """
         * Top level item
         * Top level with children
@@ -1596,9 +1587,7 @@ def test_flat_numbered_list(
     make_app: Callable[..., SphinxTestApp],
     tmp_path: Path,
 ) -> None:
-    """
-    Flat numbered lists become separate Notion NumberedItem blocks.
-    """
+    """Flat numbered lists become separate Notion NumberedItem blocks."""
     rst_content = """
         1. First numbered point
         2. Second numbered point
@@ -1624,9 +1613,7 @@ def test_numbered_list_with_inline_formatting(
     make_app: Callable[..., SphinxTestApp],
     tmp_path: Path,
 ) -> None:
-    """
-    Numbered lists preserve inline formatting in rich text.
-    """
+    """Numbered lists preserve inline formatting in rich text."""
     rst_content = """
         1. This is **bold text** in a numbered list
     """
@@ -1661,7 +1648,8 @@ def test_nested_numbered_list(
     tmp_path: Path,
 ) -> None:
     """
-    Deeply nested numbered lists create hierarchical block structures.
+    Deeply nested numbered lists create hierarchical block
+    structures.
     """
     rst_content = """
         1. Top level item
@@ -1713,7 +1701,8 @@ def test_collapse_block(
     tmp_path: Path,
 ) -> None:
     """
-    ``collapse`` directives become Notion ToggleItem blocks for expandable
+    ``collapse`` directives become Notion ToggleItem blocks for
+    expandable
     content.
     """
     rst_content = """
@@ -1758,9 +1747,7 @@ def test_simple_table(
     make_app: Callable[..., SphinxTestApp],
     tmp_path: Path,
 ) -> None:
-    """
-    Simple rST table becomes Notion Table block with header row.
-    """
+    """Simple rST table becomes Notion Table block with header row."""
     rst_content = """
         +----------+----------+
         | Header 1 | Header 2 |
@@ -1800,7 +1787,8 @@ def test_table_without_header_row(
     tmp_path: Path,
 ) -> None:
     """
-    Table without heading row becomes Notion Table block with header_row=False.
+    Table without heading row becomes Notion Table block with
+    header_row=False.
     """
     rst_content = """
         +--------+--------+
@@ -1830,9 +1818,7 @@ def test_table_inline_formatting(
     make_app: Callable[..., SphinxTestApp],
     tmp_path: Path,
 ) -> None:
-    """
-    Table headers and cells preserve inline formatting as rich text.
-    """
+    """Table headers and cells preserve inline formatting as rich text."""
     rst_content = """
         +----------------------+----------------------+
         | **Header Bold**      | *Header Italic*      |
@@ -1865,7 +1851,8 @@ def test_table_cell_non_paragraph_error(
     tmp_path: Path,
 ) -> None:
     """
-    Table cells with non-paragraph content raise a clear error message.
+    Table cells with non-paragraph content raise a clear error
+    message.
     """
     rst_content = """
         +----------+----------+
@@ -1898,9 +1885,7 @@ def test_simple_image(
     make_app: Callable[..., SphinxTestApp],
     tmp_path: Path,
 ) -> None:
-    """
-    ``image`` directives become Notion Image blocks with URL.
-    """
+    """``image`` directives become Notion Image blocks with URL."""
     rst_content = """
         .. image:: https://www.example.com/path/to/image.png
     """
@@ -1925,7 +1910,8 @@ def test_image_with_alt_text_only(
     tmp_path: Path,
 ) -> None:
     """
-    ``image`` directives with only alt text become Notion Image blocks without
+    ``image`` directives with only alt text become Notion Image blocks
+    without
     captions.
     """
     rst_content = """
@@ -1952,7 +1938,8 @@ def test_literalinclude_without_caption(
     tmp_path: Path,
 ) -> None:
     """
-    ``literalinclude`` directives without captions become code blocks.
+    ``literalinclude`` directives without captions become code
+    blocks.
     """
     rst_content = """
         .. literalinclude:: conf.py
@@ -2030,9 +2017,7 @@ def test_heading_level_4_error(
     make_app: Callable[..., SphinxTestApp],
     tmp_path: Path,
 ) -> None:
-    """
-    Heading level 4+ raises a clear error message.
-    """
+    """Heading level 4+ raises a clear error message."""
     rst_content = """
         Main Title
         ==========
@@ -2072,7 +2057,8 @@ def test_local_image_file(
     tmp_path: Path,
 ) -> None:
     """
-    Local image files are converted to file:// URLs in the JSON output.
+    Local image files are converted to file:// URLs in the JSON
+    output.
     """
     srcdir = tmp_path / "src"
     srcdir.mkdir()
@@ -2103,9 +2089,7 @@ def test_simple_video(
     make_app: Callable[..., SphinxTestApp],
     tmp_path: Path,
 ) -> None:
-    """
-    ``video`` directives become Notion Video blocks with URL.
-    """
+    """``video`` directives become Notion Video blocks with URL."""
     rst_content = """
         .. video:: https://www.example.com/path/to/video.mp4
     """
@@ -2131,7 +2115,8 @@ def test_video_with_caption(
     tmp_path: Path,
 ) -> None:
     """
-    Video directives with captions include the caption in the Notion Video
+    Video directives with captions include the caption in the Notion
+    Video
     block.
     """
     rst_content = """
@@ -2161,7 +2146,8 @@ def test_local_video_file(
     tmp_path: Path,
 ) -> None:
     """
-    Local video files are converted to file:// URLs in the JSON output.
+    Local video files are converted to file:// URLs in the JSON
+    output.
     """
     srcdir = tmp_path / "src"
     srcdir.mkdir()
@@ -2191,9 +2177,7 @@ def test_simple_audio(
     make_app: Callable[..., SphinxTestApp],
     tmp_path: Path,
 ) -> None:
-    """
-    ``audio`` directives become Notion Audio blocks with URL.
-    """
+    """``audio`` directives become Notion Audio blocks with URL."""
     rst_content = """
         .. audio:: https://www.example.com/path/to/audio.mp3
     """
@@ -2219,7 +2203,8 @@ def test_local_audio_file(
     tmp_path: Path,
 ) -> None:
     """
-    Local audio files are converted to file:// URLs in the JSON output.
+    Local audio files are converted to file:// URLs in the JSON
+    output.
     """
     srcdir = tmp_path / "src"
     srcdir.mkdir()
@@ -2250,9 +2235,11 @@ def test_strikethrough_text(
     tmp_path: Path,
 ) -> None:
     """
-    Strikethrough text using
-    `sphinxnotes-strike <https://github.com/sphinx-toolbox/sphinxnotes-strike>`_
-    becomes rich text with strikethrough formatting.
+    Strikethrough text using ``sphinxnotes-strike`` becomes rich text
+    with
+    strikethrough formatting.
+
+    See https://github.com/sphinx-toolbox/sphinxnotes-strike.
     """
     rst_content = """
         This text has :strike:`strikethrough` formatting.
@@ -2289,7 +2276,8 @@ def test_comment_ignored(
     tmp_path: Path,
 ) -> None:
     """
-    Comments in reStructuredText are ignored and do not appear in output.
+    Comments in reStructuredText are ignored and do not appear in
+    output.
     """
     rst_content = """
         This is a paragraph with content.
@@ -2321,7 +2309,8 @@ def test_list_table_header_one_allowed(
     tmp_path: Path,
 ) -> None:
     """
-    List table with header-rows option other than 0 raises ValueError.
+    List table with header-rows option other than 0 raises
+    ValueError.
     """
     rst_content = """
         .. list-table::
@@ -2354,9 +2343,7 @@ def test_list_table_header_rows_zero_allowed(
     make_app: Callable[..., SphinxTestApp],
     tmp_path: Path,
 ) -> None:
-    """
-    List table with header-rows: 0 should be allowed and processed.
-    """
+    """List table with header-rows: 0 should be allowed and processed."""
     rst_content = """
         .. list-table::
            :header-rows: 0
@@ -2385,7 +2372,8 @@ def test_list_table_header_maximum_one_allowed(
     tmp_path: Path,
 ) -> None:
     """
-    List table with header-rows option other than 0 or 1 emits a warning.
+    List table with header-rows option other than 0 or 1 emits a
+    warning.
     """
     rst_content = """
         .. list-table::
@@ -2430,7 +2418,8 @@ def test_list_table_stub_columns_one(
     tmp_path: Path,
 ) -> None:
     """
-    List table with :stub-columns: 1 creates table with header column.
+    List table with :stub-columns: 1 creates table with header
+    column.
     """
     rst_content = """
         .. list-table::
@@ -2477,9 +2466,7 @@ def test_list_table_stub_columns_two(
     make_app: Callable[..., SphinxTestApp],
     tmp_path: Path,
 ) -> None:
-    """
-    List table with :stub-columns: 2 emits a warning.
-    """
+    """List table with :stub-columns: 2 emits a warning."""
     rst_content = """
         .. list-table::
            :header-rows: 1
@@ -2530,7 +2517,8 @@ def test_list_table_with_title_error(
     tmp_path: Path,
 ) -> None:
     """
-    List table with title emits a warning since Notion tables do not have
+    List table with title emits a warning since Notion tables do not
+    have
     titles.
     """
     rst_content = """
@@ -2580,9 +2568,7 @@ def test_simple_pdf(
     tmp_path: Path,
     extensions: tuple[str, ...],
 ) -> None:
-    """
-    ``pdf-include`` directives become Notion PDF blocks with URL.
-    """
+    """``pdf-include`` directives become Notion PDF blocks with URL."""
     rst_content = """
         .. pdf-include:: https://www.example.com/path/to/document.pdf
     """
@@ -2609,9 +2595,7 @@ def test_pdf_with_options(
     make_app: Callable[..., SphinxTestApp],
     tmp_path: Path,
 ) -> None:
-    """
-    PDF directives with options (width, height) are processed correctly.
-    """
+    """PDF directives with options (width, height) are processed correctly."""
     rst_content = """
         .. pdf-include:: https://www.example.com/path/to/document.pdf
            :width: 50%
@@ -2641,7 +2625,8 @@ def test_local_pdf_file(
     tmp_path: Path,
 ) -> None:
     """
-    Local PDF files are converted to file:// URLs in the JSON output.
+    Local PDF files are converted to file:// URLs in the JSON
+    output.
     """
     srcdir = tmp_path / "src"
     srcdir.mkdir()
@@ -2679,9 +2664,7 @@ def test_pdf_with_html(
     tmp_path: Path,
     extensions: tuple[str, ...],
 ) -> None:
-    """
-    PDF directives with HTML output are processed correctly.
-    """
+    """PDF directives with HTML output are processed correctly."""
     rst_content = """
         .. pdf-include:: https://www.example.com/path/to/document.pdf
     """
@@ -2717,7 +2700,8 @@ def test_colored_text(
     tmp_path: Path,
 ) -> None:
     """
-    Colored text from ``sphinxcontrib-text-styles`` becomes rich text.
+    Colored text from ``sphinxcontrib-text-styles`` becomes rich
+    text.
     """
     rst_content = """
         This is :text-red:`red text` and :text-blue:`blue text` \
@@ -2785,9 +2769,7 @@ def test_individual_colors(
     role: str,
     expected_color: Color | BGColor,
 ) -> None:
-    """
-    Each supported color is converted correctly.
-    """
+    """Each supported color is converted correctly."""
     rst_content = f"""
         This is :{role}:`{role} text`.
     """
@@ -2819,9 +2801,7 @@ def test_text_styles_unsupported_color(
     make_app: Callable[..., SphinxTestApp],
     tmp_path: Path,
 ) -> None:
-    """
-    Unsupported colors from ``sphinxcontrib-text-styles`` emit warnings.
-    """
+    """Unsupported colors from ``sphinxcontrib-text-styles`` emit warnings."""
     rst_content = """
         This is :text-cyan:`cyan text`.
     """
@@ -2857,9 +2837,7 @@ def test_inline_node_without_classes(
     make_app: Callable[..., SphinxTestApp],
     tmp_path: Path,
 ) -> None:
-    """
-    Inline nodes without classes are handled as plain text.
-    """
+    """Inline nodes without classes are handled as plain text."""
     # Using a custom role to create an inline node without classes
     conf_py_content = """
 from docutils import nodes
@@ -2958,7 +2936,8 @@ def test_additional_text_styles(
     expected_text: Text,
 ) -> None:
     """
-    Additional text styles from the ``sphinxcontrib_text_styles`` extension are
+    Additional text styles from the ``sphinxcontrib_text_styles``
+    extension are
     supported.
     """
     rst_content = f"""
@@ -2988,9 +2967,7 @@ def test_flat_task_list(
     make_app: Callable[..., SphinxTestApp],
     tmp_path: Path,
 ) -> None:
-    """
-    Flat task lists become separate Notion ToDoItem blocks.
-    """
+    """Flat task lists become separate Notion ToDoItem blocks."""
     rst_content = """
         .. task-list::
 
@@ -3024,7 +3001,8 @@ def test_bullet_list_with_nested_content(
     tmp_path: Path,
 ) -> None:
     """
-    Test that bullet lists can contain nested content like paragraphs and
+    Test that bullet lists can contain nested content like paragraphs
+    and
     nested bullets.
     """
     rst_content = """
@@ -3077,7 +3055,8 @@ def test_task_list_with_nested_content(
     tmp_path: Path,
 ) -> None:
     """
-    Task lists with nested content should create ToDoItem blocks with nested
+    Task lists with nested content should create ToDoItem blocks with
+    nested
     children.
     """
     rst_content = """
@@ -3123,9 +3102,7 @@ def test_nested_task_list(
     make_app: Callable[..., SphinxTestApp],
     tmp_path: Path,
 ) -> None:
-    """
-    Nested task lists should create nested ToDoItem blocks.
-    """
+    """Nested task lists should create nested ToDoItem blocks."""
     rst_content = """
         .. task-list::
 
@@ -3193,9 +3170,7 @@ def test_task_list_quote(
     make_app: Callable[..., SphinxTestApp],
     tmp_path: Path,
 ) -> None:
-    """
-    A quote can exist within a task list.
-    """
+    """A quote can exist within a task list."""
     rst_content = """
     .. task-list::
 
@@ -3227,9 +3202,7 @@ def test_inline_single_backticks(
     make_app: Callable[..., SphinxTestApp],
     tmp_path: Path,
 ) -> None:
-    """
-    Reproduces a bug where we got confused by mismatching blocks.
-    """
+    """Reproduces a bug where we got confused by mismatching blocks."""
     rst_content = """
         A `B`
     """
@@ -3328,9 +3301,7 @@ def test_unsupported_node_types_in_rich_text(
     make_app: Callable[..., SphinxTestApp],
     tmp_path: Path,
 ) -> None:
-    """
-    Unsupported node types in rich text processing raise ValueError.
-    """
+    """Unsupported node types in rich text processing raise ValueError."""
     rst_content = """
         This is a test with :footnote:`footnote node`.
     """
@@ -3411,9 +3382,7 @@ def test_inline_equation(
     make_app: Callable[..., SphinxTestApp],
     tmp_path: Path,
 ) -> None:
-    """
-    Inline equations become Notion math rich text.
-    """
+    """Inline equations become Notion math rich text."""
     rst_content = """
         This is an inline equation :math:`E = mc^2` in a paragraph.
     """
@@ -3442,9 +3411,7 @@ def test_block_equation(
     make_app: Callable[..., SphinxTestApp],
     tmp_path: Path,
 ) -> None:
-    """
-    Block equations become Notion Equation blocks.
-    """
+    """Block equations become Notion Equation blocks."""
     rst_content = """
         .. math::
 
@@ -3470,7 +3437,8 @@ def test_rest_example_block(
     tmp_path: Path,
 ) -> None:
     """
-    Rest example blocks become Notion callout blocks with nested code and
+    Rest example blocks become Notion callout blocks with nested code
+    and
     description.
     """
     rst_content = """
@@ -3547,7 +3515,8 @@ def test_embed_block(
     tmp_path: Path,
 ) -> None:
     """
-    Blocks using the ``iframe`` directive become Notion Embed blocks.
+    Blocks using the ``iframe`` directive become Notion Embed
+    blocks.
     """
     rst_content = """
         .. iframe:: https://example.com/embed
@@ -3575,7 +3544,8 @@ def test_embed_and_video(
     make_app: Callable[..., SphinxTestApp],
     tmp_path: Path,
 ) -> None:
-    """``sphinx-iframes`` and ``sphinxcontrib.video`` can be used together in
+    """``sphinx-iframes`` and ``sphinxcontrib.video`` can be used together
+    in
     this with ``sphinx-notionbuilder``.
 
     We check this because there was a conflict between the two
@@ -3608,7 +3578,8 @@ def test_line_block(
     tmp_path: Path,
 ) -> None:
     """
-    Line blocks (created with pipe character) become empty Notion paragraph
+    Line blocks (created with pipe character) become empty Notion
+    paragraph
     blocks.
     """
     rst_content = """
@@ -3641,9 +3612,7 @@ def test_transition_divider(
     make_app: Callable[..., SphinxTestApp],
     tmp_path: Path,
 ) -> None:
-    """
-    Transitions (horizontal rules) become Notion Divider blocks.
-    """
+    """Transitions (horizontal rules) become Notion Divider blocks."""
     rst_content = """
         First paragraph.
 
@@ -3671,9 +3640,7 @@ def test_notion_mention_user(
     make_app: Callable[..., SphinxTestApp],
     tmp_path: Path,
 ) -> None:
-    """
-    ``notion-mention-user`` role creates user mention in paragraph.
-    """
+    """``notion-mention-user`` role creates user mention in paragraph."""
     test_user_id = "12345678-1234-1234-1234-123456789abc"
 
     rst_content = f"""
@@ -3707,9 +3674,7 @@ def test_notion_mention_page(
     make_app: Callable[..., SphinxTestApp],
     tmp_path: Path,
 ) -> None:
-    """
-    ``notion-mention-page`` role creates page mention in paragraph.
-    """
+    """``notion-mention-page`` role creates page mention in paragraph."""
     test_page_id = "87654321-4321-4321-4321-cba987654321"
 
     rst_content = f"""
@@ -3743,7 +3708,8 @@ def test_notion_mention_database(
     tmp_path: Path,
 ) -> None:
     """
-    ``notion-mention-database`` role creates database mention in paragraph.
+    ``notion-mention-database`` role creates database mention in
+    paragraph.
     """
     test_database_id = "abcdef12-3456-7890-abcd-ef1234567890"
 
@@ -3777,9 +3743,7 @@ def test_notion_mention_date(
     make_app: Callable[..., SphinxTestApp],
     tmp_path: Path,
 ) -> None:
-    """
-    ``notion-mention-date`` role creates date mention in paragraph.
-    """
+    """``notion-mention-date`` role creates date mention in paragraph."""
     test_date = "2025-11-09"
 
     rst_content = f"""
@@ -3813,9 +3777,7 @@ def test_notion_mention_user_html_output(
     make_app: Callable[..., SphinxTestApp],
     tmp_path: Path,
 ) -> None:
-    """
-    ``notion-mention-user`` role with HTML builder generates a link.
-    """
+    """``notion-mention-user`` role with HTML builder generates a link."""
     test_user_id = "12345678-1234-1234-1234-123456789abc"
     rst_content = f"""
         Hello :notion-mention-user:`{test_user_id}` there!
@@ -3842,9 +3804,7 @@ def test_notion_mention_page_html_output(
     make_app: Callable[..., SphinxTestApp],
     tmp_path: Path,
 ) -> None:
-    """
-    ``notion-mention-page`` role with HTML builder generates a link.
-    """
+    """``notion-mention-page`` role with HTML builder generates a link."""
     test_page_id = "87654321-4321-4321-4321-cba987654321"
     rst_content = f"""
         See :notion-mention-page:`{test_page_id}` for details.
@@ -3871,9 +3831,7 @@ def test_notion_mention_database_html_output(
     make_app: Callable[..., SphinxTestApp],
     tmp_path: Path,
 ) -> None:
-    """
-    ``notion-mention-database`` role with HTML builder generates a link.
-    """
+    """``notion-mention-database`` role with HTML builder generates a link."""
     test_database_id = "abcdef12-3456-7890-abcd-ef1234567890"
     rst_content = f"""
         Check the :notion-mention-database:`{test_database_id}` database.
@@ -3900,9 +3858,7 @@ def test_notion_mention_date_html_output(
     make_app: Callable[..., SphinxTestApp],
     tmp_path: Path,
 ) -> None:
-    """
-    ``notion-mention-date`` role with HTML builder shows the date.
-    """
+    """``notion-mention-date`` role with HTML builder shows the date."""
     test_date = "2025-11-09"
     rst_content = f"""
         The meeting is on :notion-mention-date:`{test_date}`.
@@ -3929,7 +3885,8 @@ def test_describe_directive(
     tmp_path: Path,
 ) -> None:
     """
-    ``describe`` directive becomes a Notion Callout block with nested content.
+    ``describe`` directive becomes a Notion Callout block with nested
+    content.
     """
     rst_content = """
         .. describe:: Foo
@@ -3967,7 +3924,8 @@ def test_describe_directive_multiline(
     tmp_path: Path,
 ) -> None:
     """
-    ``describe`` directive with multiple paragraphs nests all content.
+    ``describe`` directive with multiple paragraphs nests all
+    content.
     """
     rst_content = """
         .. describe:: Bar

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -1,6 +1,4 @@
-"""
-Tests for the upload script.
-"""
+"""Tests for the upload script."""
 
 from click.testing import CliRunner
 from pytest_regressions.file_regression import FileRegressionFixture


### PR DESCRIPTION
Replace docformatter with pydocstringformatter.

This follows the same pattern as https://github.com/VWS-Python/vws-python/pull/2793.

Changes:
- Replace `docformatter==1.7.7` with `pydocstringformatter==0.7.3`
- Update tool configuration in pyproject.toml
- Update ruff ignore rules (D200 → D205, D212)
- Format docstrings with new tool
- Workaround URL breaking issue by isolating URLs on their own lines where needed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces the docstring formatter and aligns configs and code accordingly.
> 
> - Swap `docformatter` for `pydocstringformatter` in `.pre-commit-config.yaml` and `pyproject.toml`; add `[tool.pydocstringformatter]` config and remove `[tool.docformatter]`
> - Update Ruff ignores to allow `D205`/`D212` (with per-file `D200` where needed)
> - Reformat docstrings across `src/`, `tests/`, and `sample/` to single-line summaries/line-wrapped bodies; adjust URL lines to avoid wrapping issues
> - No functional code changes; only formatting and configuration updates
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c4dbb0ed235f5e457d34da312f2c8faa418c3cd0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->