### PR TITLE
Remove --example-workers 0 due to mypy bug

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -122,8 +122,8 @@ repos:
 
       - id: shellcheck-docs
         name: shellcheck-docs
-        entry: uv run --extra=dev doccmd --no-write-to-file --example-workers 0 --language=shell
-          --language=console --command="shellcheck --shell=bash"
+        entry: uv run --extra=dev doccmd --no-write-to-file --language=shell --language=console
+          --command="shellcheck --shell=bash"
         language: python
         types_or: [markdown, rst]
         additional_dependencies: [uv==0.9.5]
@@ -183,8 +183,7 @@ repos:
       - id: pyright-docs
         name: pyright-docs
         stages: [pre-push]
-        entry: uv run --extra=dev doccmd --no-write-to-file --example-workers 0 --language=python
-          --command="pyright"
+        entry: uv run --extra=dev doccmd --no-write-to-file --language=python --command="pyright"
         language: python
         types_or: [markdown, rst]
         additional_dependencies: [uv==0.9.5]
@@ -200,8 +199,7 @@ repos:
 
       - id: vulture-docs
         name: vulture docs
-        entry: uv run --extra=dev doccmd --no-write-to-file --example-workers 0 --language=python
-          --command="vulture"
+        entry: uv run --extra=dev doccmd --no-write-to-file --language=python --command="vulture"
         language: python
         types_or: [markdown, rst]
         additional_dependencies: [uv==0.9.5]
@@ -234,8 +232,7 @@ repos:
 
       - id: pylint-docs
         name: pylint-docs
-        entry: uv run --extra=dev doccmd --no-write-to-file --example-workers 0 --language=python
-          --command="pylint"
+        entry: uv run --extra=dev doccmd --no-write-to-file --language=python --command="pylint"
         language: python
         stages: [manual]
         types_or: [markdown, rst]
@@ -292,8 +289,7 @@ repos:
 
       - id: interrogate-docs
         name: interrogate docs
-        entry: uv run --extra=dev doccmd --no-write-to-file --example-workers 0 --language=python
-          --command="interrogate"
+        entry: uv run --extra=dev doccmd --no-write-to-file --language=python --command="interrogate"
         language: python
         types_or: [markdown, rst]
         additional_dependencies: [uv==0.9.5]
@@ -363,8 +359,8 @@ repos:
       - id: ty-docs
         name: ty-docs
         stages: [pre-push]
-        entry: uv run --extra=dev doccmd --no-write-to-file --example-workers 0 --language=python
-          --command="ty check"
+        entry: uv run --extra=dev doccmd --no-write-to-file --language=python --command="ty
+          check"
         language: python
         types_or: [markdown, rst]
         additional_dependencies: [uv==0.9.5]
@@ -381,8 +377,8 @@ repos:
       - id: pyrefly-docs
         name: pyrefly-docs
         stages: [pre-push]
-        entry: uv run --extra=dev doccmd --no-write-to-file --example-workers 0 --language=python
-          --command="pyrefly check"
+        entry: uv run --extra=dev doccmd --no-write-to-file --language=python --command="pyrefly
+          check"
         language: python
         types_or: [markdown, rst]
         additional_dependencies: [uv==0.9.5]


### PR DESCRIPTION
This removes `--example-workers 0` from the pre-commit config due to a mypy race condition bug.

See https://github.com/python/mypy/issues/18283

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates `.pre-commit-config.yaml` to simplify documentation checker hooks and avoid a mypy race condition.
> 
> - Drops `--example-workers 0` from `doccmd` invocations (mypy-related issue) and standardizes to `--no-write-to-file` with explicit `--language` and `--command`
> - Streamlines `doccmd` entries for `shellcheck-docs`, `pyright-docs`, `vulture-docs`, `pylint-docs`, `interrogate-docs`, `ty-docs`, and `pyrefly-docs`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 73b1ac4a87db44b49201df9495b7a85d71493a95. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->