### PR TITLE
Support Python 3.14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
   build:
     strategy:
       matrix:
-        python-version: ['3.12', '3.13']
+        python-version: ['3.12', '3.13', '3.14']
         platform: [ubuntu-latest, windows-latest]
         lint-stage: [pre-commit, pre-push, manual]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ classifiers = [
     "Programming Language :: Python :: 3 :: Only",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
 ]
 dynamic = [
     "version",
@@ -341,7 +342,7 @@ pep621_dev_dependency_groups = [
 [tool.pyproject-fmt]
 indent = 4
 keep_full_version = true
-max_supported_python = "3.13"
+max_supported_python = "3.14"
 
 [tool.pytest.ini_options]
 


### PR DESCRIPTION
Add Python 3.14 to the test matrix and classifiers.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds official Python 3.14 support across CI and packaging metadata.
> 
> - Extends GitHub Actions `ci.yml` matrix to include `python-version: '3.14'` on Ubuntu/Windows
> - Adds `Programming Language :: Python :: 3.14` classifier in `pyproject.toml`
> - Bumps `tool.pyproject-fmt.max_supported_python` to `3.14`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit db636164b1035c3092d462b35ec09374fb08b4b7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->