### PR TITLE
Add ty error-on-warning configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -375,6 +375,14 @@ enableTypeIgnoreComments = false
 reportUnnecessaryTypeIgnoreComment = true
 typeCheckingMode = "strict"
 
+[tool.ty.analysis]
+# Disable support for `type: ignore` comments
+respect-type-ignore-comments = false
+
+[tool.ty.terminal]
+# Error if ty emits any warning-level diagnostics.
+error-on-warning = true
+
 [tool.pydocstringformatter]
 write = true
 split-summary-body = false


### PR DESCRIPTION
Add ty configuration:
- respect-type-ignore-comments = false (for mypy compatibility)
- error-on-warning = true

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `ty` configuration in `pyproject.toml`:
> 
> - `tool.ty.analysis.respect-type-ignore-comments = false` to ignore `type: ignore` comments
> - `tool.ty.terminal.error-on-warning = true` to treat warnings as errors
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7ac5c609e5aee41c99a6415acca6d203996f8a30. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->