### PR TITLE
Add update sample script

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -295,12 +295,6 @@ For contributors, a helper script is provided to build and publish the sample do
    $ export NOTION_SAMPLE_PAGE_ID="your_sample_page_id_here"
    $ uv run python scripts/update_sample.py
 
-Use ``--dry-run`` to see what commands would be executed without running them:
-
-.. code-block:: console
-
-   $ uv run python scripts/update_sample.py --dry-run
-
 .. |Build Status| image:: https://github.com/adamtheturtle/sphinx-notionbuilder/actions/workflows/ci.yml/badge.svg?branch=main
    :target: https://github.com/adamtheturtle/sphinx-notionbuilder/actions
 .. |PyPI| image:: https://badge.fury.io/py/Sphinx-Notion-Builder.svg

--- a/scripts/update_sample.py
+++ b/scripts/update_sample.py
@@ -11,10 +11,6 @@ Or pass them directly::
 
     NOTION_TOKEN=xxx NOTION_SAMPLE_PAGE_ID=yyy \
         uv run python scripts/update_sample.py
-
-For a dry-run (shows commands without executing)::
-
-    uv run python scripts/update_sample.py --dry-run
 """
 
 import shutil
@@ -38,17 +34,9 @@ import click
     required=True,
     help="ID of the parent Notion page",
 )
-@click.option(
-    "--dry-run",
-    is_flag=True,
-    default=False,
-    help="Show the commands that would be run without executing them",
-)
 def main(
     notion_token: str,
     notion_page_id: str,
-    *,
-    dry_run: bool,
 ) -> None:
     """Build and publish the sample documentation to Notion."""
     del notion_token  # Used by environment, not directly
@@ -86,18 +74,6 @@ def main(
         "--icon",
         "🐍",
     ]
-
-    if dry_run:
-        click.echo(message="Would run:")
-        click.echo(message=f"  {' '.join(build_cmd)}")
-        click.echo()
-        click.echo(message="Then:")
-        click.echo(message=f"  {' '.join(upload_cmd)}")
-        click.echo()
-        click.echo(message="With environment:")
-        click.echo(message="  NOTION_TOKEN=***")
-        click.echo(message=f"  NOTION_SAMPLE_PAGE_ID={notion_page_id}")
-        return
 
     # Clean build directory
     if build_dir.exists():


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: adds a contributor-only helper script and README instructions, with no changes to library/runtime behavior. Main risk is environment/tooling assumptions (`uv`, extras, Notion env vars) when contributors run the script.
> 
> **Overview**
> Adds a new contributor helper `scripts/update_sample.py` that builds the `sample/` docs with the Notion builder and then publishes the generated `index.json` to a configured Notion parent page via `notion-upload`.
> 
> Updates `README.rst` with brief instructions and required env vars (`NOTION_TOKEN`, `NOTION_SAMPLE_PAGE_ID`) for running the script locally.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7052e2e414eaf8dbf835ad81cdc162639f39b78d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->