### PR TITLE
Add local publish-sample script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -211,3 +211,5 @@ uv.lock
 build-sample/
 
 *.DS_Store
+
+.secrets

--- a/README.rst
+++ b/README.rst
@@ -284,6 +284,26 @@ Arguments:
 
 The command will create a new page if one with the given title doesn't exist, or update the existing page if one with the given title already exists.
 
+Publishing the Sample Document Locally
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+A convenience script is provided to build and publish the sample documentation to a test Notion page.
+
+#. Create a ``.env`` file in the repository root with the following variables:
+
+   .. code-block:: shell
+
+      export NOTION_TOKEN=your_integration_token_here
+      export NOTION_SAMPLE_DATABASE_ID=your_database_id_here
+
+   This file is gitignored and will not be committed.
+
+#. Run the script:
+
+   .. code-block:: console
+
+      $ ./publish-sample.sh
+
 .. |Build Status| image:: https://github.com/adamtheturtle/sphinx-notionbuilder/actions/workflows/ci.yml/badge.svg?branch=main
    :target: https://github.com/adamtheturtle/sphinx-notionbuilder/actions
 .. |PyPI| image:: https://badge.fury.io/py/Sphinx-Notion-Builder.svg

--- a/publish-sample.sh
+++ b/publish-sample.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+set -a
+# shellcheck source=/dev/null
+source "${SCRIPT_DIR}/.env"
+set +a
+
+rm -rf ./build-sample
+uv run --extra=sample sphinx-build -W -b notion sample ./build-sample
+
+uv run --all-extras notion-upload \
+    --parent-database-id "$NOTION_SAMPLE_DATABASE_ID" \
+    --file "./build-sample/index.json" \
+    --title "Test page title during testing" \
+    --icon "🐍"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -329,6 +329,7 @@ ignore = [
     "tests",
     "tests-pylintrc",
     "tests/**",
+    "publish-sample.sh",
     "zizmor.yml",
 ]
 


### PR DESCRIPTION
Add a convenience script (`publish-sample.sh`) to build and publish the sample documentation to a Notion database locally.

The script sources `NOTION_TOKEN` and `NOTION_SAMPLE_DATABASE_ID` from a `.env` file (gitignored) and mirrors the CI workflow.

Also adds `.secrets` to `.gitignore` and documents usage in the README.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a convenience shell script and documentation with minor ignore/manifests tweaks; no changes to runtime library behavior.
> 
> **Overview**
> Adds a local `publish-sample.sh` helper that builds the `sample/` docs with the Notion builder (via `uv`) and uploads the generated `index.json` to a configured Notion database using `notion-upload`.
> 
> Documents the local publishing workflow in `README.rst`, and updates housekeeping to avoid committing local secrets/output by gitignoring `.secrets` and ensuring `publish-sample.sh` is excluded from source distributions via `check-manifest`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c949fb0b042379af0b063eb3ed76bea38fa842a7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->