### PR TITLE
Use SCRIPT_DIR consistently in publish-sample.sh

### DIFF
--- a/publish-sample.sh
+++ b/publish-sample.sh
@@ -9,11 +9,11 @@ set -a
 source "${SCRIPT_DIR}/.env"
 set +a
 
-rm -rf ./build-sample
-uv run --extra=sample sphinx-build -W -b notion sample ./build-sample
+rm -rf "${SCRIPT_DIR}/build-sample"
+uv run --extra=sample sphinx-build -W -b notion "${SCRIPT_DIR}/sample" "${SCRIPT_DIR}/build-sample"
 
 uv run --all-extras notion-upload \
     --parent-database-id "$NOTION_SAMPLE_DATABASE_ID" \
-    --file "./build-sample/index.json" \
+    --file "${SCRIPT_DIR}/build-sample/index.json" \
     --title "Test page title during testing" \
     --icon "🐍"


### PR DESCRIPTION
Fix paths in `publish-sample.sh` to use `${SCRIPT_DIR}` consistently instead of relative paths.

Previously, the script computed `SCRIPT_DIR` but only used it for sourcing `.env`. All other operations (`rm -rf`, `sphinx-build`, `notion-upload --file`) used relative paths from the current working directory. If invoked from outside the repo root, this would operate on wrong directories.

Fixes the issue raised in https://github.com/adamtheturtle/sphinx-notionbuilder/pull/539#pullrequestreview-3766752102

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small shell path changes that only affect where artifacts are built and uploaded; low risk aside from potential path typos.
> 
> **Overview**
> Updates `publish-sample.sh` to use `${SCRIPT_DIR}`-anchored paths for the build output, Sphinx input/output directories, and the `notion-upload --file` argument instead of relative paths.
> 
> This makes the script behave correctly when invoked from outside the repo root and avoids deleting/building/uploading from the wrong working directory.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3eb5871f879546ae82c820ac62a1e0df77989e25. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->