### PR TITLE
Add cross-reference style classes to ignored list

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -219,7 +219,7 @@ Cross-references
 Sphinx cross-reference roles are not fully supported by the Notion builder because there is no way to determine the URL of the target page in Notion.
 Cross-references that resolve to internal links are rendered as plain text and a build warning is emitted.
 
-The affected roles include ``:doc:``, ``:ref:``, and ``:any:``.
+The affected roles include ``:doc:``, ``:ref:``, ``:any:``, ``:numref:``, ``:keyword:``, ``:option:``, and ``:download:``.
 
 Unsupported Notion Block Types
 ------------------------------

--- a/src/sphinx_notion/__init__.py
+++ b/src/sphinx_notion/__init__.py
@@ -581,6 +581,13 @@ def _create_styled_text_from_node(*, node: nodes.Element) -> Text:
         "xref",
         "py",
         "py-obj",
+        "std",
+        "std-envvar",
+        "std-keyword",
+        "std-numref",
+        "std-option",
+        "std-term",
+        "download",
     }
     unsupported_styles = [
         css_class

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -2086,6 +2086,152 @@ def test_cross_reference_any(
     )
 
 
+def test_cross_reference_download(
+    *,
+    make_app: Callable[..., SphinxTestApp],
+    tmp_path: Path,
+) -> None:
+    """:download: references render as code text."""
+    rst_content = """
+        Download :download:`conf.py` here.
+    """
+
+    expected_blocks = [
+        UnoParagraph(
+            text=text(text="Download ")
+            + text(text="conf.py", code=True)
+            + text(text=" here.")
+        ),
+    ]
+
+    _assert_rst_converts_to_notion_objects(
+        rst_content=rst_content,
+        expected_blocks=expected_blocks,
+        make_app=make_app,
+        tmp_path=tmp_path,
+    )
+
+
+def test_cross_reference_numref(
+    *,
+    make_app: Callable[..., SphinxTestApp],
+    tmp_path: Path,
+) -> None:
+    """``:numref:`` references render as plain text via style class
+    handling.
+    """
+    rst_content = """
+        .. _my-table:
+
+        .. table:: My Table
+
+           ====== ======
+           Col1   Col2
+           ====== ======
+           A      B
+           ====== ======
+
+        See :numref:`my-table` for data.
+    """
+
+    srcdir = tmp_path / "src"
+    srcdir.mkdir(exist_ok=True)
+
+    index_rst = srcdir / "index.rst"
+    expected_warnings = [
+        "Table has a title 'My Table' on line 3 in "
+        f"{index_rst}, but Notion tables do not have titles.",
+    ]
+
+    table = UnoTable(n_rows=2, n_cols=2, header_row=True)
+    table[0, 0] = text(text="Col1")
+    table[0, 1] = text(text="Col2")
+    table[1, 0] = text(text="A")
+    table[1, 1] = text(text="B")
+
+    expected_blocks = [
+        table,
+        UnoParagraph(text=text(text="See Table 1 for data.")),
+    ]
+
+    _assert_rst_converts_to_notion_objects(
+        rst_content=rst_content,
+        expected_blocks=expected_blocks,
+        make_app=make_app,
+        tmp_path=tmp_path,
+        expected_warnings=expected_warnings,
+        confoverrides={"numfig": True},
+    )
+
+
+def test_cross_reference_keyword(
+    *,
+    make_app: Callable[..., SphinxTestApp],
+    tmp_path: Path,
+) -> None:
+    """:keyword: references render as plain text."""
+    rst_content = """
+        Test :keyword:`with` here.
+    """
+
+    index_rst = tmp_path / "src" / "index.rst"
+    expected_warnings = [
+        f"{index_rst}:1:",
+        "unknown keyword: 'with' [ref.keyword]",
+    ]
+
+    expected_blocks = [
+        UnoParagraph(
+            text=text(text="Test ")
+            + text(text="with", code=True)
+            + text(text=" here.")
+        ),
+    ]
+
+    _assert_rst_converts_to_notion_objects(
+        rst_content=rst_content,
+        expected_blocks=expected_blocks,
+        make_app=make_app,
+        tmp_path=tmp_path,
+        expected_warnings=expected_warnings,
+    )
+
+
+def test_cross_reference_option(
+    *,
+    make_app: Callable[..., SphinxTestApp],
+    tmp_path: Path,
+) -> None:
+    """:option: references render as plain text."""
+    rst_content = """
+        .. program:: myprogram
+
+        Test :option:`myprogram --verbose` here.
+    """
+
+    index_rst = tmp_path / "src" / "index.rst"
+    expected_warnings = [
+        f"{index_rst}:3:",
+        "unknown option: 'myprogram --verbose' [ref.option]",
+    ]
+
+    expected_blocks = [
+        UnoParagraph(
+            text=text(text="Test ")
+            + text(text="myprogram --verbose", code=True)
+            + text(text=" here.")
+        ),
+    ]
+
+    _assert_rst_converts_to_notion_objects(
+        rst_content=rst_content,
+        expected_blocks=expected_blocks,
+        make_app=make_app,
+        tmp_path=tmp_path,
+        expected_warnings=expected_warnings,
+    )
+
+
 def test_literalinclude_with_caption(
     make_app: Callable[..., SphinxTestApp],
     tmp_path: Path,


### PR DESCRIPTION
## Summary
- Adds `std`, `std-envvar`, `std-keyword`, `std-numref`, `std-option`, `std-term`, and `download` to the ignored CSS style classes, preventing spurious "unsupported text style" warnings for Sphinx cross-reference roles.
- Adds integration tests for `:download:`, `:numref:`, `:keyword:`, and `:option:` cross-reference roles.
- Updates README to list the additional affected roles.

Extracted from #542.

## Test plan
- [x] All 149 tests pass
- [x] mypy passes
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, warning-only behavior change limited to CSS class filtering plus added tests/docs; no core rendering logic or data handling is modified.
> 
> **Overview**
> Reduces spurious "Unsupported text style" warnings by expanding the ignored CSS class allowlist for Sphinx cross-reference nodes (adds `std*` variants and `download`).
> 
> Adds integration coverage ensuring `:download:`, `:numref:`, `:keyword:`, and `:option:` roles render without unsupported-style warnings (and with expected output/warnings), and updates the README to list these additional affected roles.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bf4c9e0880079a1c77c1a0dbf7f1b33fab25645a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->