### PR TITLE
Handle :download: references with a warning

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -219,7 +219,7 @@ Cross-references
 Sphinx cross-reference roles are not fully supported by the Notion builder because there is no way to determine the URL of the target page in Notion.
 Cross-references that resolve to internal links are rendered as plain text and a build warning is emitted.
 
-The affected roles include ``:doc:``, ``:ref:``, and ``:any:``.
+The affected roles include ``:doc:``, ``:ref:``, ``:any:``, and ``:download:``.
 
 Unsupported Notion Block Types
 ------------------------------

--- a/src/sphinx_notion/__init__.py
+++ b/src/sphinx_notion/__init__.py
@@ -405,6 +405,25 @@ def _(node: nodes.reference) -> Text:
 
 @beartype
 @_process_rich_text_node.register
+def _(node: addnodes.download_reference) -> Text:
+    """Process download reference nodes by rendering children with a
+    warning.
+    """
+    _LOGGER.warning(
+        "Download references are not supported by the Notion builder. "
+        "Rendering as plain text.",
+        type="ref",
+        subtype="notion",
+        location=node,
+    )
+    result = Text.from_plain_text(text="")
+    for child in node.children:
+        result += _process_rich_text_node(child)
+    return result
+
+
+@beartype
+@_process_rich_text_node.register
 def _(node: nodes.target) -> Text:
     """
     Process target nodes by returning empty text (targets are
@@ -581,6 +600,7 @@ def _create_styled_text_from_node(*, node: nodes.Element) -> Text:
         "xref",
         "py",
         "py-obj",
+        "download",
     }
     unsupported_styles = [
         css_class

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -2086,6 +2086,40 @@ def test_cross_reference_any(
     )
 
 
+def test_cross_reference_download(
+    *,
+    make_app: Callable[..., SphinxTestApp],
+    tmp_path: Path,
+) -> None:
+    """:download: references render as code text with a warning."""
+    rst_content = """
+        Download :download:`conf.py` here.
+    """
+
+    index_rst = tmp_path / "src" / "index.rst"
+    expected_warnings = [
+        f"{index_rst}:1:",
+        "Download references are not supported by the Notion builder. "
+        "Rendering as plain text. [ref.notion]",
+    ]
+
+    expected_blocks = [
+        UnoParagraph(
+            text=text(text="Download ")
+            + text(text="conf.py", code=True)
+            + text(text=" here.")
+        ),
+    ]
+
+    _assert_rst_converts_to_notion_objects(
+        rst_content=rst_content,
+        expected_blocks=expected_blocks,
+        make_app=make_app,
+        tmp_path=tmp_path,
+        expected_warnings=expected_warnings,
+    )
+
+
 def test_literalinclude_with_caption(
     make_app: Callable[..., SphinxTestApp],
     tmp_path: Path,


### PR DESCRIPTION
## Summary
- Adds a dedicated `_process_rich_text_node` handler for `addnodes.download_reference` that processes children (preserving code formatting from the inner literal node) and emits a `[ref.notion]` warning that download links are not supported.
- Adds `download` to the ignored CSS style classes to prevent a spurious "unsupported text style" warning.
- Updates README to list `:download:` among affected roles.

Previously, `:download:` references were silently handled by the `nodes.reference` handler (since `download_reference` inherits from it) and rendered as plain text with no indication that the download link was lost.

Extracted from #542.

## Test plan
- [x] All 146 tests pass
- [x] mypy passes
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, well-scoped changes limited to rich-text rendering and warning behavior; adds test coverage and does not affect authentication, data persistence, or external API calls.
> 
> **Overview**
> Adds an explicit rich-text handler for Sphinx `:download:` references (`addnodes.download_reference`) so they **emit a `[ref.notion]` warning** and render as plain text while still processing children (preserving inner formatting like code).
> 
> Suppresses spurious styling warnings by ignoring the `download` CSS class during text-style processing, and updates the README to document `:download:` as an affected cross-reference role. Includes an integration test covering the new warning + rendering behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b100c79545232e0dd7480ba047fafe912669a4e3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->