### PR TITLE
Bump pyproject-fmt from 2.12.1 to 2.14.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,9 +39,7 @@ dependencies = [
     "cloup>=3.0.0",
     "docutils>=0.21",
     "requests>=2.32.5",
-    # Pin Sphinx to <9 to avoid
-    # https://github.com/sphinx-toolbox/sphinx-toolbox/issues/201
-    "sphinx>=8.2.3,<9",
+    "sphinx>=8.2.3,<9",            # Pin to <9: https://github.com/sphinx-toolbox/sphinx-toolbox/issues/201
     "sphinx-iframes>=1.1.0",
     "sphinx-immaterial>=0.13.7",
     "sphinx-simplepdf>=1.6.0",
@@ -68,7 +66,7 @@ optional-dependencies.dev = [
     "pygments==2.19.2",
     "pylint[spelling]==4.0.4",
     "pylint-per-file-ignores==3.2.0",
-    "pyproject-fmt==2.12.1",
+    "pyproject-fmt==2.14.0",
     "pyrefly==0.51.1",
     "pyright==1.1.408",
     "pyroma==5.0.1",
@@ -77,10 +75,7 @@ optional-dependencies.dev = [
     "pytest-regressions==2.9.1",
     "pyyaml==6.0.3",
     "ruff==0.15.0",
-    # We add shellcheck-py not only for shell scripts and shell code blocks,
-    # but also because having it installed means that ``actionlint-py`` will
-    # use it to lint shell commands in GitHub workflow files.
-    "shellcheck-py==0.11.0.1",
+    "shellcheck-py==0.11.0.1",                   # Also needed so actionlint-py lints shell in GitHub workflows
     "shfmt-py==3.12.0.2",
     "sphinx-lint==1.0.2",
     "sphinx-pyproject==0.3.0",
@@ -99,28 +94,22 @@ optional-dependencies.sample = [
     "sphinxcontrib-text-styles==0.2.1",
 ]
 urls.Source = "https://github.com/adamtheturtle/sphinx-notionbuilder"
-
 scripts.notion-upload = "_notion_scripts.upload:main"
 scripts.upload-files = "_notion_scripts.upload_files:main"
 
 [tool.setuptools]
 zip-safe = false
-
-[tool.setuptools.package-data]
-sphinx_notion = [
+package-data.sphinx_notion = [
     "py.typed",
 ]
-
-[tool.setuptools.packages.find]
-where = [
+packages.find.where = [
     "src",
 ]
 
-[tool.distutils.bdist_wheel]
-universal = true
+[tool.distutils]
+bdist_wheel.universal = true
 
 [tool.setuptools_scm]
-
 # This keeps the start of the version the same as the last release.
 # This is useful for our documentation to include e.g. binary links
 # to the latest released binary.
@@ -130,44 +119,29 @@ version_scheme = "post-release"
 
 [tool.ruff]
 line-length = 79
-
 lint.select = [
     "ALL",
 ]
 lint.ignore = [
-    # Ruff warns that this conflicts with the formatter.
-    "COM812",
-    # Allow our chosen docstring line-style - pydocstringformatter handles formatting
-    # but doesn't enforce D205 (blank line after summary) or D212 (summary on first line).
-    "D205",
-    "D212",
-    # Ruff warns that this conflicts with the formatter.
-    "ISC001",
-    # Ignore "too-many-*" errors as they seem to get in the way more than
-    # helping.
-    "PLR0913",
-    # We use asserts for type narrowing.
-    "S101",
+    "COM812",  # Ruff warns that this conflicts with the formatter.
+    "D205",    # Allow our chosen docstring line-style - pydocstringformatter handles formatting
+    "D212",    # but doesn't enforce D205 (blank line after summary) or D212 (summary on first line).
+    "ISC001",  # Ruff warns that this conflicts with the formatter.
+    "PLR0913", # Ignore 'too-many-*' errors as they seem to get in the way more than helping.
+    "S101",    # We use asserts for type narrowing.
 ]
-
 lint.per-file-ignores."doccmd_*.py" = [
-    # Allow our chosen docstring line-style - pydocstringformatter handles
-    # formatting but docstrings in docs may not match this style.
-    "D200",
-    # Allow asserts in docs.
-    "S101",
+    "D200", # Allow our chosen docstring line-style
+    "S101", # Allow asserts in docs.
 ]
-
 lint.per-file-ignores."docs/source/*.py" = [
     # Allow asserts in docs.
     "S101",
 ]
-
 lint.per-file-ignores."tests/*.py" = [
     # Allow asserts in tests.
     "S101",
 ]
-
 # Do not automatically remove commented out code.
 # We comment out code during development, and with VSCode auto-save, this code
 # is sometimes annoyingly removed.
@@ -177,21 +151,13 @@ lint.unfixable = [
 lint.pydocstyle.convention = "google"
 
 [tool.pylint]
-
-[tool.pylint.'FORMAT']
-
 # Allow the body of an if to be on the same line as the test if there is no
 # else.
-single-line-if-stmt = false
-
-[tool.pylint.'MASTER']
-
+"FORMAT".single-line-if-stmt = false
 # Pickle collected data for later comparisons.
-persistent = true
-
+"MASTER".persistent = true
 # Use multiple processes to speed up Pylint.
-jobs = 0
-
+"MASTER".jobs = 0
 # List of plugins (as comma separated values of python modules names) to load,
 # usually to register additional checkers.
 # See https://chezsoi.org/lucas/blog/pylint-strict-base-configuration.html.
@@ -201,44 +167,39 @@ jobs = 0
 # - pylint.extensions.magic_value
 # - pylint.extensions.while_used
 # as they seemed to get in the way.
-load-plugins = [
+"MASTER".load-plugins = [
     "pylint_per_file_ignores",
-    'pylint.extensions.bad_builtin',
-    'pylint.extensions.comparison_placement',
-    'pylint.extensions.consider_refactoring_into_while_condition',
-    'pylint.extensions.docparams',
-    'pylint.extensions.dunder',
-    'pylint.extensions.eq_without_hash',
-    'pylint.extensions.for_any_all',
-    'pylint.extensions.mccabe',
-    'pylint.extensions.no_self_use',
-    'pylint.extensions.overlapping_exceptions',
-    'pylint.extensions.private_import',
-    'pylint.extensions.redefined_loop_name',
-    'pylint.extensions.redefined_variable_type',
-    'pylint.extensions.set_membership',
-    'pylint.extensions.typing',
+    "pylint.extensions.bad_builtin",
+    "pylint.extensions.comparison_placement",
+    "pylint.extensions.consider_refactoring_into_while_condition",
+    "pylint.extensions.docparams",
+    "pylint.extensions.dunder",
+    "pylint.extensions.eq_without_hash",
+    "pylint.extensions.for_any_all",
+    "pylint.extensions.mccabe",
+    "pylint.extensions.no_self_use",
+    "pylint.extensions.overlapping_exceptions",
+    "pylint.extensions.private_import",
+    "pylint.extensions.redefined_loop_name",
+    "pylint.extensions.redefined_variable_type",
+    "pylint.extensions.set_membership",
+    "pylint.extensions.typing",
 ]
-
 # Allow loading of arbitrary C extensions. Extensions are imported into the
 # active Python interpreter and may run arbitrary code.
-unsafe-load-any-extension = false
-
-[tool.pylint.'MESSAGES CONTROL']
-
+"MASTER".unsafe-load-any-extension = false
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option
 # multiple time (only on the command line, not in the configuration file where
 # it should appear only once). See also the "--disable" option for examples.
-enable = [
-    'bad-inline-option',
-    'deprecated-pragma',
-    'file-ignored',
-    'spelling',
-    'use-symbolic-message-instead',
-    'useless-suppression',
+"MESSAGES CONTROL".enable = [
+    "bad-inline-option",
+    "deprecated-pragma",
+    "file-ignored",
+    "spelling",
+    "use-symbolic-message-instead",
+    "useless-suppression",
 ]
-
 # Disable the message, report, category or checker with the given id(s). You
 # can either give multiple identifiers separated by comma (,) or put this
 # option multiple times (only on the command line, not in the configuration
@@ -248,60 +209,44 @@ enable = [
 # --enable=similarities". If you want to run only the classes checker, but have
 # no Warning level messages displayed, use"--disable=all --enable=classes
 # --disable=W"
-
-disable = [
-    'too-few-public-methods',
-    'too-many-locals',
-    'too-many-arguments',
-    'too-many-instance-attributes',
-    'too-many-return-statements',
-    'too-many-lines',
-    'locally-disabled',
-    # Let ruff handle long lines
-    'line-too-long',
-    # Let ruff handle unused imports
-    'unused-import',
-    # Let ruff deal with sorting
-    'ungrouped-imports',
-    # We don't need everything to be documented because of mypy
-    'missing-type-doc',
-    'missing-return-type-doc',
-    # Too difficult to please
-    'duplicate-code',
-    # Let ruff handle imports
-    'wrong-import-order',
-    # mypy does not want untyped parameters.
-    'useless-type-doc',
-    # interacts poorly with singledispatch
-    "bad-dunder-name",
+"MESSAGES CONTROL".disable = [
+    "too-few-public-methods",
+    "too-many-locals",
+    "too-many-arguments",
+    "too-many-instance-attributes",
+    "too-many-return-statements",
+    "too-many-lines",
+    "locally-disabled",
+    "line-too-long",                # Let ruff handle long lines
+    "unused-import",                # Let ruff handle unused imports
+    "ungrouped-imports",            # Let ruff deal with sorting
+    "missing-type-doc",             # We don't need everything to be documented because of mypy
+    "missing-return-type-doc",
+    "duplicate-code",               # Too difficult to please
+    "wrong-import-order",           # Let ruff handle imports
+    "useless-type-doc",             # mypy does not want untyped parameters.
+    "bad-dunder-name",              # interacts poorly with singledispatch
 ]
-
 # We ignore invalid names because:
 # - We want to use generated module names, which may not be valid, but are never seen.
 # - We want to use global variables in documentation, which may not be uppercase.
 # - conf.py is a Sphinx configuration file which requires lowercase global variable names.
-per-file-ignores = [
+"MESSAGES CONTROL".per-file-ignores = [
     "docs/source/conf.py:invalid-name",
     "docs/source/doccmd_*.py:invalid-name",
     "doccmd_README_rst_*.py:invalid-name",
     "sample/conf.py:invalid-name",
 ]
-
-[tool.pylint.'SPELLING']
-
 # Spelling dictionary name. Available dictionaries: none. To make it working
 # install python-enchant package.
-spelling-dict = 'en_US'
-
+"SPELLING".spelling-dict = "en_US"
 # A path to a file that contains private dictionary; one word per line.
-spelling-private-dict-file = 'spelling_private_dict.txt'
-
+"SPELLING".spelling-private-dict-file = "spelling_private_dict.txt"
 # Tells whether to store unknown words to indicated private dictionary in
 # --spelling-private-dict-file option instead of raising a message.
-spelling-store-unknown-words = 'no'
+"SPELLING".spelling-store-unknown-words = "no"
 
 [tool.check-manifest]
-
 ignore = [
     "CLAUDE.md",
     ".checkmake-config.ini",
@@ -345,28 +290,23 @@ indent = 4
 keep_full_version = true
 max_supported_python = "3.14"
 
-[tool.pytest.ini_options]
+[tool.pytest]
+ini_options.xfail_strict = true
+ini_options.log_cli = true
 
-xfail_strict = true
-log_cli = true
-
-[tool.coverage.report]
-exclude_also = [
+[tool.coverage]
+report.exclude_also = [
     "if TYPE_CHECKING:",
 ]
-
-[tool.coverage.run]
-
-branch = true
+run.branch = true
 # These files interact with the Notion API and cannot be tested until we have
 # a Notion mock. See https://github.com/adamtheturtle/sphinx-notionbuilder/issues/525.
-omit = [
+run.omit = [
     "src/_notion_scripts/upload.py",
     "src/sphinx_notion/_upload.py",
 ]
 
 [tool.mypy]
-
 strict = true
 files = [ "." ]
 exclude = [ "build" ]
@@ -376,18 +316,15 @@ plugins = [
 ]
 
 [tool.pyright]
-
 enableTypeIgnoreComments = false
 reportUnnecessaryTypeIgnoreComment = true
 typeCheckingMode = "strict"
 
-[tool.ty.analysis]
+[tool.ty]
 # Disable support for `type: ignore` comments
-respect-type-ignore-comments = false
-
-[tool.ty.terminal]
+analysis.respect-type-ignore-comments = false
 # Error if ty emits any warning-level diagnostics.
-error-on-warning = true
+terminal.error-on-warning = true
 
 [tool.pydocstringformatter]
 write = true
@@ -401,7 +338,6 @@ omit-covered-files = true
 verbose = 2
 
 [tool.doc8]
-
 max_line_length = 2000
 ignore_path = [
     "./.eggs",
@@ -470,7 +406,6 @@ ignore_names = [
     "option_spec",
     "run",
 ]
-
 # Duplicate some of .gitignore
 exclude = [ ".venv" ]
 


### PR DESCRIPTION
Work around https://github.com/tox-dev/toml-fmt/issues/184 by moving in-array comments to inline comments.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to dependency/tooling version bump and TOML config reformatting; risk is mainly tooling/config parsing differences across CI environments.
> 
> **Overview**
> Bumps the dev dependency `pyproject-fmt` from `2.12.1` to `2.14.0`.
> 
> Reformats `pyproject.toml` to the newer style, including moving in-array comments to inline comments and adjusting several tool config sections to dotted-key form (e.g., `setuptools` package data/find config, `pytest`/`coverage` nesting, and `pylint` section keys). No functional runtime code changes are included.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fdd11d2fa06669aa1a8ee6536b25d9f12db7c4ae. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->