### PR TITLE
Use rest-example in sample_warnings

### DIFF
--- a/sample_warnings/conf.py
+++ b/sample_warnings/conf.py
@@ -8,6 +8,7 @@ sys.path.insert(0, str(object=Path(__file__).parent))
 extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.autosummary",
+    "sphinx_toolbox.rest_example",
     "sphinx_notion",
 ]
 

--- a/sample_warnings/index.rst
+++ b/sample_warnings/index.rst
@@ -7,19 +7,23 @@ The warnings are suppressed via ``suppress_warnings = ["ref.notion"]`` in ``conf
 Cross-references
 ~~~~~~~~~~~~~~~~
 
-A reference to a label: :ref:`other-doc-label`.
+.. rest-example::
 
-A reference to a document: :doc:`other`.
+   A reference to a label: :ref:`other-doc-label`.
 
-A download reference: :download:`example.txt <_static/example.txt>`.
+   A reference to a document: :doc:`other`.
+
+   A download reference: :download:`example.txt <_static/example.txt>`.
 
 Autosummary
 ~~~~~~~~~~~
 
-.. autosummary::
-   :nosignatures:
+.. rest-example::
 
-   example_module.greet
+   .. autosummary::
+      :nosignatures:
+
+      example_module.greet
 
 .. toctree::
 


### PR DESCRIPTION
Use `rest-example` in `sample_warnings` like we do in `sample`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change that tweaks Sphinx extensions and sample markup; low risk aside from needing the `sphinx_toolbox` extension available in the docs build.
> 
> **Overview**
> Updates the `sample_warnings` Sphinx sample to use `sphinx_toolbox.rest_example` by enabling the extension in `conf.py` and wrapping the cross-reference and autosummary snippets in `.. rest-example::` blocks.
> 
> This restructures `index.rst` so the previously inline/bulleted example directives and references render as a grouped, copyable reST example while keeping the same showcased references and warnings suppression behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0ec78c532a92593a26e68e3624766bee970109ad. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->