### PR TITLE
Bump pyproject-fmt to 2.14.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,10 +38,10 @@ dependencies = [
     "click>=8.0.0",
     "cloup>=3.0.0",
     "docutils>=0.21",
+    "requests>=2.32.5",
     # Pin Sphinx to <9 to avoid
     # https://github.com/sphinx-toolbox/sphinx-toolbox/issues/201
     "sphinx>=8.2.3,<9",
-    "requests>=2.32.5",
     "sphinx-iframes>=1.1.0",
     "sphinx-immaterial>=0.13.7",
     "sphinx-simplepdf>=1.6.0",
@@ -68,7 +68,7 @@ optional-dependencies.dev = [
     "pygments==2.19.2",
     "pylint[spelling]==4.0.4",
     "pylint-per-file-ignores==3.2.0",
-    "pyproject-fmt==2.14.0",
+    "pyproject-fmt==2.14.2",
     "pyrefly==0.51.2",
     "pyright==1.1.408",
     "pyroma==5.0.1",
@@ -77,6 +77,10 @@ optional-dependencies.dev = [
     "pytest-regressions==2.9.1",
     "pyyaml==6.0.3",
     "ruff==0.15.0",
+    # We add shellcheck-py not only for shell scripts and shell code blocks,
+    # but also because having it installed means that ``actionlint-py`` will
+    # use it to lint shell commands in GitHub workflow files.
+    "shellcheck-py==0.11.0.1",
     "shfmt-py==3.12.0.2",
     "sphinx-lint==1.0.2",
     "sphinx-pyproject==0.3.0",
@@ -87,10 +91,6 @@ optional-dependencies.dev = [
     "types-docutils==0.22.3.20251115",
     "types-requests==2.32.4.20260107",
     "vulture==2.14",
-    # We add shellcheck-py not only for shell scripts and shell code blocks,
-    # but also because having it installed means that ``actionlint-py`` will
-    # use it to lint shell commands in GitHub workflow files.
-    "shellcheck-py==0.11.0.1",
     "yamlfix==1.19.1",
     "zizmor==1.22.0",
 ]
@@ -128,26 +128,26 @@ lint.select = [
     "ALL",
 ]
 lint.ignore = [
+    # Ruff warns that this conflicts with the formatter.
+    "COM812",
     # Allow our chosen docstring line-style - pydocstringformatter handles formatting
     # but doesn't enforce D205 (blank line after summary) or D212 (summary on first line).
     "D205",
+    "D212",
+    # Ruff warns that this conflicts with the formatter.
+    "ISC001",
     # Ignore 'too-many-*' errors as they seem to get in the way more than
     # helping.
     "PLR0913",
-    # Ruff warns that this conflicts with the formatter.
-    "COM812",
-    # Ruff warns that this conflicts with the formatter.
-    "ISC001",
     # We use asserts for type narrowing.
     "S101",
-    "D212",
 ]
 lint.per-file-ignores."doccmd_*.py" = [
-    # Allow asserts in docs.
-    "S101",
     # Allow our chosen docstring line-style - pydocstringformatter handles
     # formatting but docstrings in docs may not match this style.
     "D200",
+    # Allow asserts in docs.
+    "S101",
 ]
 lint.per-file-ignores."docs/source/*.py" = [
     # Allow asserts in docs.


### PR DESCRIPTION
Bump pyproject-fmt from 2.14.0 to 2.14.2 and re-format.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Configuration-only changes (tooling and lint settings) with no runtime code paths affected; risk is limited to potential CI/lint behavior differences.
> 
> **Overview**
> Updates dev tooling by bumping `pyproject-fmt` from `2.14.0` to `2.14.2` and reformatting `pyproject.toml` accordingly (mostly ordering/comment placement changes).
> 
> Also tweaks lint configuration in `tool.ruff` by adding ignores for formatter-conflicting rules (`COM812`, `ISC001`) and adjusting the placement/order of existing ignores and per-file ignores.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7e96d6816e99b5d76816f65f363196e47dd05d90. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->