### PR TITLE
Add support for :download: role

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -253,7 +253,7 @@ Cross-references
 Sphinx cross-reference roles are not fully supported by the Notion builder because there is no way to determine the URL of the target page in Notion.
 Cross-references that resolve to internal links are rendered as plain text and a build warning is emitted.
 
-The affected roles include ``:doc:``, ``:ref:``, ``:term:``, ``:any:``, ``:numref:``, ``:keyword:``, ``:option:``, ``:envvar:``, ``:confval:``, ``:token:``, and ``:download:``.
+The affected roles include ``:doc:``, ``:ref:``, ``:term:``, ``:any:``, ``:numref:``, ``:keyword:``, ``:option:``, ``:envvar:``, ``:confval:``, and ``:token:``.
 
 To suppress these warnings, add the following to your ``conf.py``:
 

--- a/sample/index.rst
+++ b/sample/index.rst
@@ -421,6 +421,15 @@ Files
 
    .. notion-file:: _static/test-file.txt
 
+Downloads
+~~~~~~~~~
+
+.. rest-example::
+
+   Download :download:`conf.py` here.
+
+   Download an external file :download:`https://www.w3.org/WAI/ER/tests/xhtml/testfiles/resources/pdf/dummy.pdf` here.
+
 Mathematical Equations
 ~~~~~~~~~~~~~~~~~~~~~~
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -2138,22 +2138,61 @@ def test_cross_reference_download(
     make_app: Callable[..., SphinxTestApp],
     tmp_path: Path,
 ) -> None:
-    """:download: references render as code text with a warning."""
+    """:download: references render as linked text."""
     rst_content = """
         Download :download:`conf.py` here.
     """
 
-    index_rst = tmp_path / "src" / "index.rst"
-    expected_warnings = [
-        f"{index_rst}:1:",
-        "Download references are not supported by the Notion builder. "
-        "Rendering as plain text. [ref.notion]",
-    ]
+    srcdir = tmp_path / "src"
+    conf_py_url = (srcdir / "conf.py").as_uri()
+
+    expected_warnings: list[str] = []
 
     expected_blocks = [
         UnoParagraph(
             text=text(text="Download ")
-            + text(text="conf.py", code=True)
+            + text(
+                text="conf.py",
+                href=conf_py_url,
+                bold=False,
+                italic=False,
+                code=False,
+            )
+            + text(text=" here.")
+        ),
+    ]
+
+    _assert_rst_converts_to_notion_objects(
+        rst_content=rst_content,
+        expected_blocks=expected_blocks,
+        make_app=make_app,
+        tmp_path=tmp_path,
+        expected_warnings=expected_warnings,
+    )
+
+
+def test_cross_reference_download_external_url(
+    *,
+    make_app: Callable[..., SphinxTestApp],
+    tmp_path: Path,
+) -> None:
+    """:download: references with external URLs render as linked text."""
+    rst_content = """
+        Download :download:`https://example.com/file.zip` here.
+    """
+
+    expected_warnings: list[str] = []
+
+    expected_blocks = [
+        UnoParagraph(
+            text=text(text="Download ")
+            + text(
+                text="https://example.com/file.zip",
+                href="https://example.com/file.zip",
+                bold=False,
+                italic=False,
+                code=False,
+            )
             + text(text=" here.")
         ),
     ]


### PR DESCRIPTION
## Summary
Implement proper handling of Sphinx download references by rendering them as linked text in Notion instead of plain text with a warning. Local file references are converted to file:// URIs while external URLs are used as-is.

## Test plan
- All 163 existing tests pass
- New test for local file downloads
- New test for external URL downloads
- Full test coverage maintained at 100%
- Sample documentation updated with examples

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, well-scoped change to rich-text rendering plus test/doc updates; main risk is incorrect local path resolution to `file://` URIs across environments.
> 
> **Overview**
> Adds support for Sphinx `:download:` references in the Notion builder by rendering them as linked rich text instead of plain text with a warning; local targets are resolved to `file://` URIs when `refuri` is absent.
> 
> Updates integration coverage to assert link output for both local-file and external-URL downloads, and refreshes docs/sample content to include `:download:` examples and remove it from the list of unsupported cross-reference roles.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2ddfa660833d2e2f2823afa8debdc9eb86453c28. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->