### PR TITLE
Update pyproject-fmt to 2.15.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -322,15 +322,15 @@ ini_options.xfail_strict = true
 ini_options.log_cli = true
 
 [tool.coverage]
-report.exclude_also = [
-    "if TYPE_CHECKING:",
-]
 run.branch = true
 # These files interact with the Notion API and cannot be tested until we have
 # a Notion mock. See https://github.com/adamtheturtle/sphinx-notionbuilder/issues/525.
 run.omit = [
     "src/_notion_scripts/upload.py",
     "src/sphinx_notion/_upload.py",
+]
+report.exclude_also = [
+    "if TYPE_CHECKING:",
 ]
 
 [tool.mypy]


### PR DESCRIPTION
Update pyproject-fmt to 2.15.2.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure configuration reformatting with no behavioral changes expected beyond tool parsing equivalent TOML.
> 
> **Overview**
> Updates `pyproject.toml` formatting in the `[tool.coverage]` section by relocating `report.exclude_also` below `run.omit` (no value changes), matching the output/ordering of the newer `pyproject-fmt` version.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8c81ca781e3a945755d7675f3715a610fe11037a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->