### PR TITLE
Matrix lint workflow by hook stage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,10 @@ jobs:
           uv run --extra=dev --python=${{ matrix.python-version }} pytest -s -vvv --cov-fail-under 100 --cov=src/ --cov=tests/ .
 
   lint:
+    strategy:
+      matrix:
+        hook-stage: [pre-commit, pre-push, manual]
+
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -66,10 +70,8 @@ jobs:
         # Use bash to ensure the step fails if any command fails.
         # PowerShell does not fail on intermediate command failures by default.
         shell: bash
-        run: |
-          uv run --extra=dev prek run --all-files --hook-stage pre-commit --verbose
-          uv run --extra=dev prek run --all-files --hook-stage pre-push --verbose
-          uv run --extra=dev prek run --all-files --hook-stage manual --verbose
+        run: uv run --extra=dev prek run --all-files --hook-stage ${{ matrix.hook-stage }}
+          --verbose
         env:
           UV_PYTHON: '3.13'
 


### PR DESCRIPTION
Refactor the lint workflow to parallelize hook stage execution by adding `hook-stage` to the build matrix. This runs all three hook stages (pre-commit, pre-push, manual) in parallel instead of sequentially.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow refactor that changes job parallelism but not application/runtime code; main risk is CI timeouts or reporting differences if one matrix leg fails.
> 
> **Overview**
> The `lint` GitHub Actions job is refactored to run as a matrix over `hook-stage` (`pre-commit`, `pre-push`, `manual`), so each stage executes in its own parallel job.
> 
> The lint step now runs a single `prek` invocation parameterized by `${{ matrix.hook-stage }}` rather than running all three stages sequentially in one runner.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6598712d8a87217759bf43d53849ee306d0738a7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->