### PR TITLE
Add pyrefly non-exhaustive match as error

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -342,6 +342,9 @@ plugins = [
     "mypy_strict_kwargs",
 ]
 
+[tool.pyrefly]
+errors.non-exhaustive-match = "error"
+
 [tool.pyright]
 enableTypeIgnoreComments = false
 reportUnnecessaryTypeIgnoreComment = true
@@ -439,6 +442,3 @@ exclude = [ ".venv" ]
 [tool.yamlfix]
 section_whitelines = 1
 whitelines = 1
-
-[tool.pyrefly]
-errors.non-exhaustive-match = "error"


### PR DESCRIPTION
Adds \ to \ in project \ files.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single configuration change that only affects static analysis severity; runtime behavior is unchanged.
> 
> **Overview**
> Tightens static analysis by adding a `[tool.pyrefly]` configuration in `pyproject.toml` that upgrades `errors.non-exhaustive-match` to **error** severity, causing CI/linting to fail when `match` statements are not exhaustive.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8660d933b34fbb03c0fe9db4f94e0b3dc9872575. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->