### PR TITLE
Test page icon and cover via page object

### DIFF
--- a/tests/notion_sandbox/notion-openapi.yml
+++ b/tests/notion_sandbox/notion-openapi.yml
@@ -146,6 +146,13 @@ paths:
                       id: 71e95936-2737-4e11-b03d-f174f6f13e90
                     archived: false
                     in_trash: false
+                    icon:
+                      type: emoji
+                      emoji: 📝
+                    cover:
+                      type: external
+                      external:
+                        url: https://example.com/cover.png
                     parent:
                       type: workspace
                       workspace: true
@@ -200,6 +207,13 @@ paths:
                       id: 71e95936-2737-4e11-b03d-f174f6f13e90
                     archived: false
                     in_trash: false
+                    icon:
+                      type: emoji
+                      emoji: 📝
+                    cover:
+                      type: external
+                      external:
+                        url: https://example.com/cover.png
                     parent:
                       type: workspace
                       workspace: true


### PR DESCRIPTION
## Summary
- Updated mock API responses to include `icon` and `cover` fields in page PATCH endpoints
- Changed `test_upload_with_icon` to assert on `page.icon` instead of just checking logs
- Changed `test_upload_with_cover_url` to assert on `page.cover` type and URL instead of just checking logs
- Added `ExternalFile` import to test file

## Test plan
- All 172 tests pass, including the 4 mock API integration tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes update the Microcks mock OpenAPI responses and tighten assertions around `page.icon`/`page.cover`, with no production code paths modified.
> 
> **Overview**
> Updates the Microcks-backed Notion sandbox OpenAPI examples for page `PATCH` responses to include `icon` (emoji) and `cover` (external URL) fields.
> 
> Adjusts the upload integration tests to assert on the returned `page` object (`page.icon`, and `page.cover` as an `ExternalFile` with the expected URL) instead of relying on log output, adding the needed `ExternalFile` import.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 184fa3bbf4038a42b428ee513be58830e31ba389. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->