### PR TITLE
Add upload tests for subpages and databases errors

### DIFF
--- a/tests/test_upload_mock_api.py
+++ b/tests/test_upload_mock_api.py
@@ -24,6 +24,10 @@ from ultimate_notion.blocks import (
 from ultimate_notion.rich_text import text
 
 import sphinx_notion._upload as notion_upload
+from sphinx_notion._upload import (
+    PageHasDatabasesError,
+    PageHasSubpagesError,
+)
 
 pytestmark = pytest.mark.skipif(
     os.environ.get("SKIP_DOCKER_TESTS") == "1",
@@ -250,3 +254,39 @@ def test_upload_with_cover_url(
     assert str(object=page.id) == parent_page_id
     assert isinstance(page.cover, ExternalFile)
     assert page.cover.url == "https://example.com/cover.png"
+
+
+def test_upload_page_has_subpages_error(
+    notion_session: Session,
+) -> None:
+    """PageHasSubpagesError raised when the target page has subpages."""
+    with pytest.raises(expected_exception=PageHasSubpagesError):
+        notion_upload.upload_to_notion(
+            session=notion_session,
+            blocks=[],
+            parent_page_id="aaaa0000-0000-0000-0000-000000000001",
+            parent_database_id=None,
+            title="Upload Title",
+            icon=None,
+            cover_path=None,
+            cover_url=None,
+            cancel_on_discussion=False,
+        )
+
+
+def test_upload_page_has_databases_error(
+    notion_session: Session,
+) -> None:
+    """PageHasDatabasesError raised when the target page has databases."""
+    with pytest.raises(expected_exception=PageHasDatabasesError):
+        notion_upload.upload_to_notion(
+            session=notion_session,
+            blocks=[],
+            parent_page_id="bbbb0000-0000-0000-0000-000000000001",
+            parent_database_id=None,
+            title="Upload Title",
+            icon=None,
+            cover_path=None,
+            cover_url=None,
+            cancel_on_discussion=False,
+        )


### PR DESCRIPTION
This adds two upload mock API tests for error paths when the target page contains child pages or child databases. It imports PageHasSubpagesError and PageHasDatabasesError in tests/test_upload_mock_api.py and asserts each exception is raised for dedicated fixture page IDs. PR diff: 1 file changed, 40 insertions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes that add coverage for existing error paths; no production logic is modified.
> 
> **Overview**
> Adds two new mock-API integration tests to `tests/test_upload_mock_api.py` to verify `upload_to_notion` raises `PageHasSubpagesError` and `PageHasDatabasesError` when the target page contains child pages or child databases.
> 
> The tests import these exception types and assert they are raised for dedicated fixture page IDs, improving coverage of upload failure paths.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit aabeab1bfd8a566c0b1a73cfc50682b6c5793a49. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->