### PR TITLE
Rename microcks_base_url to mock_api_base_url

### DIFF
--- a/tests/test_upload_mock_api.py
+++ b/tests/test_upload_mock_api.py
@@ -61,8 +61,8 @@ def _upload_wiremock_mappings(*, base_url: str, mappings_path: Path) -> None:
     response.raise_for_status()
 
 
-@pytest.fixture(name="microcks_base_url", scope="module")
-def fixture_microcks_base_url_fixture(
+@pytest.fixture(name="mock_api_base_url", scope="module")
+def fixture_mock_api_base_url_fixture(
     request: pytest.FixtureRequest,
 ) -> Iterator[str]:
     """Provide a prepared mock service base URL."""
@@ -101,12 +101,12 @@ def fixture_microcks_base_url_fixture(
 @pytest.fixture(name="notion_session")
 def fixture_notion_session_fixture(
     *,
-    microcks_base_url: str,
+    mock_api_base_url: str,
     monkeypatch: pytest.MonkeyPatch,
 ) -> Iterator[Session]:
     """Provide an `ultimate_notion` session wired to the mock API."""
     monkeypatch.setenv(name="NOTION_TOKEN", value="wiremock-test-token")
-    session = Session(base_url=microcks_base_url)
+    session = Session(base_url=mock_api_base_url)
     yield session
     session.close()
 


### PR DESCRIPTION
## Summary
- Rename the test fixture from `microcks_base_url` to `mock_api_base_url`.
- Update the fixture function name and the dependent `notion_session` parameter to match.
- Keep behavior unchanged; this is a naming consistency update in `tests/test_upload_mock_api.py`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure test-fixture renaming with no behavioral changes; main risk is breaking tests if any external references to the old fixture name exist.
> 
> **Overview**
> Renames the pytest fixture providing the WireMock/mock API base URL from `microcks_base_url` to `mock_api_base_url` in `tests/test_upload_mock_api.py`.
> 
> Updates the dependent `notion_session` fixture to accept `mock_api_base_url` and pass it into `Session(base_url=...)`, keeping the test logic unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0a00336bfe433029544c182792e08ddf2b946f3a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->