### PR TITLE
Rename leftover Microcks references to WireMock

### DIFF
--- a/spelling_private_dict.txt
+++ b/spelling_private_dict.txt
@@ -1,7 +1,7 @@
 Args
 CLI
-Microcks
 SVG
+WireMock
 autodoc
 autosummary
 backtick

--- a/tests/notion_sandbox/notion-wiremock-stubs.json
+++ b/tests/notion_sandbox/notion-wiremock-stubs.json
@@ -335,9 +335,9 @@
                   {
                     "type": "text",
                     "text": {
-                      "content": "Hello from Microcks upload test"
+                      "content": "Hello from WireMock upload test"
                     },
-                    "plain_text": "Hello from Microcks upload test",
+                    "plain_text": "Hello from WireMock upload test",
                     "annotations": {
                       "bold": false,
                       "italic": false,
@@ -391,9 +391,9 @@
                   {
                     "type": "text",
                     "text": {
-                      "content": "Hello from Microcks upload test"
+                      "content": "Hello from WireMock upload test"
                     },
-                    "plain_text": "Hello from Microcks upload test",
+                    "plain_text": "Hello from WireMock upload test",
                     "annotations": {
                       "bold": false,
                       "italic": false,
@@ -441,9 +441,9 @@
               {
                 "type": "text",
                 "text": {
-                  "content": "Hello from Microcks upload test"
+                  "content": "Hello from WireMock upload test"
                 },
-                "plain_text": "Hello from Microcks upload test",
+                "plain_text": "Hello from WireMock upload test",
                 "annotations": {
                   "bold": false,
                   "italic": false,
@@ -3273,9 +3273,9 @@
                   {
                     "type": "text",
                     "text": {
-                      "content": "Hello from Microcks upload test"
+                      "content": "Hello from WireMock upload test"
                     },
-                    "plain_text": "Hello from Microcks upload test",
+                    "plain_text": "Hello from WireMock upload test",
                     "annotations": {
                       "bold": false,
                       "italic": false,

--- a/tests/test_upload_mock_api.py
+++ b/tests/test_upload_mock_api.py
@@ -117,7 +117,7 @@ def fixture_parent_page_id() -> str:
     return "59833787-2cf9-4fdf-8782-e53db20768a5"
 
 
-def test_upload_to_notion_with_microcks(
+def test_upload_to_notion_with_wiremock(
     notion_session: Session,
     parent_page_id: str,
 ) -> None:
@@ -125,7 +125,7 @@ def test_upload_to_notion_with_microcks(
     page = notion_upload.upload_to_notion(
         session=notion_session,
         blocks=[
-            UnoParagraph(text=text(text="Hello from Microcks upload test"))
+            UnoParagraph(text=text(text="Hello from WireMock upload test"))
         ],
         parent_page_id=parent_page_id,
         parent_database_id=None,
@@ -141,7 +141,7 @@ def test_upload_to_notion_with_microcks(
     assert str(object=page.id) == parent_page_id
     assert len(page.blocks) == 1
     assert isinstance(page.blocks[0], UnoParagraph)
-    assert page.blocks[0].rich_text == "Hello from Microcks upload test"
+    assert page.blocks[0].rich_text == "Hello from WireMock upload test"
 
 
 def test_upload_deletes_and_replaces_changed_blocks(
@@ -183,7 +183,7 @@ def test_upload_with_icon(
     page = notion_upload.upload_to_notion(
         session=notion_session,
         blocks=[
-            UnoParagraph(text=text(text="Hello from Microcks upload test"))
+            UnoParagraph(text=text(text="Hello from WireMock upload test"))
         ],
         parent_page_id=parent_page_id,
         parent_database_id=None,
@@ -207,7 +207,7 @@ def test_upload_with_cover_url(
     page = notion_upload.upload_to_notion(
         session=notion_session,
         blocks=[
-            UnoParagraph(text=text(text="Hello from Microcks upload test"))
+            UnoParagraph(text=text(text="Hello from WireMock upload test"))
         ],
         parent_page_id=parent_page_id,
         parent_database_id=None,


### PR DESCRIPTION
## Summary
- Rename the mock API upload test from `test_upload_to_notion_with_microcks` to `test_upload_to_notion_with_wiremock`.
- Replace remaining "Hello from Microcks upload test" strings with "Hello from WireMock upload test" in test assertions and WireMock stubs.
- Update `spelling_private_dict.txt` from `Microcks` to `WireMock`.

## Testing
- `uv run --all-extras pytest`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only string/name updates plus a spellcheck whitelist change; no production logic affected.
> 
> **Overview**
> Renames the upload mock API test to `test_upload_to_notion_with_wiremock` and updates the test payload/asserted paragraph text from “Hello from Microcks upload test” to “Hello from WireMock upload test”.
> 
> Updates the WireMock stub JSON responses to return the new text, and adds `WireMock` to `spelling_private_dict.txt` to avoid spellcheck failures.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8b12cff0971d52df1a465b3405ecfa25f96ecab0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->