### PR TITLE
Pin WireMock Docker image tag in mock upload test

### DIFF
--- a/tests/test_upload_mock_api.py
+++ b/tests/test_upload_mock_api.py
@@ -76,7 +76,8 @@ def fixture_mock_api_base_url_fixture(
 
     docker_client = docker.from_env()
     container = docker_client.containers.run(
-        image="wiremock/wiremock:latest",
+        # This tag is arbitrary, but pinning is better than `latest`.
+        image="wiremock/wiremock:3.9.1",
         detach=True,
         remove=True,
         ports={"8080/tcp": ("127.0.0.1", 0)},


### PR DESCRIPTION
Replace the Docker image reference in the mock upload integration test from wiremock/wiremock:latest to wiremock/wiremock:3.9.1. Add a clarifying comment that the selected tag is arbitrary but intentionally stable so test behavior does not drift with latest. This reduces test flakiness risk from upstream image changes while preserving existing fixture behavior.