### PR TITLE
Reword docstrings in upload mock API tests

### DIFF
--- a/tests/test_upload_mock_api.py
+++ b/tests/test_upload_mock_api.py
@@ -121,7 +121,7 @@ def test_upload_to_notion_with_microcks(
     notion_session: Session,
     parent_page_id: str,
 ) -> None:
-    """Run upload synchronization against a mock API."""
+    """It is possible to upload a page with the mock API."""
     page = notion_upload.upload_to_notion(
         session=notion_session,
         blocks=[
@@ -179,7 +179,7 @@ def test_upload_with_icon(
     notion_session: Session,
     parent_page_id: str,
 ) -> None:
-    """Upload with an emoji icon exercises the icon PATCH path."""
+    """It is possible to upload a page with an emoji icon."""
     page = notion_upload.upload_to_notion(
         session=notion_session,
         blocks=[
@@ -203,7 +203,7 @@ def test_upload_with_cover_url(
     notion_session: Session,
     parent_page_id: str,
 ) -> None:
-    """Upload with a cover URL exercises the ExternalFile cover path."""
+    """It is possible to upload a page with a cover URL."""
     page = notion_upload.upload_to_notion(
         session=notion_session,
         blocks=[


### PR DESCRIPTION
This PR rewords three existing docstrings in `tests/test_upload_mock_api.py`.

The test behavior and assertions are unchanged; only wording was updated for:
- `test_upload_to_notion_with_microcks`
- `test_upload_with_icon`
- `test_upload_with_cover_url`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docstring-only edits in tests with no runtime or behavioral impact.
> 
> **Overview**
> Rewords docstrings for three upload integration tests in `tests/test_upload_mock_api.py` to be more direct about expected behavior (mock API upload, emoji icon upload, and cover URL upload).
> 
> No test logic or assertions are changed; this is documentation-only within the test suite.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit eb37ea6c2bac5d3626a088e505f1e7e6b976647a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->