### PR TITLE
Port selected upload tests from cover-upload

### DIFF
--- a/tests/test_upload_mock_api.py
+++ b/tests/test_upload_mock_api.py
@@ -146,7 +146,8 @@ def test_upload_to_notion_with_wiremock(
         cancel_on_discussion=False,
     )
 
-    assert page.title.startswith("Upload Title")
+    assert page.title is not None
+    assert str(object=page.title).startswith("Upload Title")
     assert page.url == "https://www.notion.so/Upload-Title-59833787"
     assert str(object=page.id) == parent_page_id
     assert len(page.blocks) == 1
@@ -175,7 +176,8 @@ def test_upload_deletes_and_replaces_changed_blocks(
             cancel_on_discussion=True,
         )
 
-    assert page.title.startswith("Upload Title")
+    assert page.title is not None
+    assert str(object=page.title).startswith("Upload Title")
     assert str(object=page.id) == parent_page_id
     expected_match_log = (
         "0 prefix and 0 suffix blocks match, 1 to delete, 1 to upload"
@@ -205,7 +207,8 @@ def test_upload_with_icon(
         cancel_on_discussion=False,
     )
 
-    assert page.title.startswith("Upload Title")
+    assert page.title is not None
+    assert str(object=page.title).startswith("Upload Title")
     assert str(object=page.id) == parent_page_id
     assert page.icon == "\N{MEMO}"
 
@@ -230,7 +233,8 @@ def test_upload_with_cover_url(
         cancel_on_discussion=False,
     )
 
-    assert page.title.startswith("Upload Title")
+    assert page.title is not None
+    assert str(object=page.title).startswith("Upload Title")
     assert str(object=page.id) == parent_page_id
     assert isinstance(page.cover, ExternalFile)
     assert page.cover.url == "https://example.com/cover.png"
@@ -339,7 +343,8 @@ def test_upload_with_database_parent(
     after_count_response.raise_for_status()
     after_count = after_count_response.json()["count"]
 
-    assert page.title.startswith("Upload Title")
+    assert page.title is not None
+    assert str(object=page.title).startswith("Upload Title")
     assert after_count == before_count + 1
 
 
@@ -367,7 +372,8 @@ def test_upload_with_cover_path(
         cancel_on_discussion=False,
     )
 
-    assert page.title.startswith("Upload Title")
+    assert page.title is not None
+    assert str(object=page.title).startswith("Upload Title")
     assert str(object=page.id) == parent_page_id
     assert isinstance(page.cover, ExternalFile)
     assert page.cover.url == "https://example.com/cover.png"


### PR DESCRIPTION
## Summary
- port `test_upload_discussions_exist_error`
- port `test_upload_with_database_parent`
- port `test_upload_with_cover_path`
- include `DiscussionsExistError` import needed by the new tests

## Notes
- this intentionally excludes unrelated changes from `adamtheturtle/cover-upload`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes that expand integration coverage around upload edge-cases; low impact on production code, with minor risk of introducing flaky/incorrect assertions in opt-in Docker tests.
> 
> **Overview**
> Improves the WireMock-based upload integration suite by generating a unique `upload_title` per run (avoiding collisions) and relaxing title assertions to prefix checks.
> 
> Adds new mock-API tests covering **discussion-protected block deletion** (`DiscussionsExistError`), **uploading to a database parent** (verifying the database `query` call count increases), and **uploading with a local cover file** (ensuring a cover `ExternalFile` URL is set).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 906acb3258516fc430d6b97ecbb580992860f5d2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->