### PR TITLE
Extract test_upload_discussions_exist_error

### DIFF
--- a/tests/test_upload_mock_api.py
+++ b/tests/test_upload_mock_api.py
@@ -24,6 +24,7 @@ from ultimate_notion.rich_text import text
 
 import sphinx_notion._upload as notion_upload
 from sphinx_notion._upload import (
+    DiscussionsExistError,
     PageHasDatabasesError,
     PageHasSubpagesError,
 )
@@ -258,4 +259,29 @@ def test_upload_page_has_databases_error(
             cover_path=None,
             cover_url=None,
             cancel_on_discussion=False,
+        )
+
+
+def test_upload_discussions_exist_error(
+    notion_session: Session,
+) -> None:
+    """DiscussionsExistError raised when blocks to delete have discussions."""
+    with pytest.raises(
+        expected_exception=DiscussionsExistError,
+        match=r"1 block.*1 discussion",
+    ):
+        notion_upload.upload_to_notion(
+            session=notion_session,
+            blocks=[
+                UnoParagraph(
+                    text=text(text="Different content triggers sync"),
+                ),
+            ],
+            parent_page_id="cccc0000-0000-0000-0000-000000000001",
+            parent_database_id=None,
+            title="Upload Title",
+            icon=None,
+            cover_path=None,
+            cover_url=None,
+            cancel_on_discussion=True,
         )


### PR DESCRIPTION
## Summary
- extract `test_upload_discussions_exist_error` from #599 into a standalone PR
- add the `DiscussionsExistError` import needed by the new test

## Testing
- `pytest tests/test_upload_mock_api.py -k discussions_exist_error` *(fails in this environment: `ModuleNotFoundError: No module named 'docker'` during test collection)*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change that adds coverage for an existing error path; no production logic is modified.
> 
> **Overview**
> Adds a new opt-in WireMock integration test that exercises the `cancel_on_discussion` path during sync and asserts `upload_to_notion` raises `DiscussionsExistError` (with an expected message) when changed content would require deleting blocks that have existing discussions.
> 
> Also updates the test module imports to include `DiscussionsExistError`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 038e9d1251eb65fc0d873ab5060557cf2b826d0a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->