### PR TITLE
Add upload discussions-exist error test

### DIFF
--- a/tests/test_upload_mock_api.py
+++ b/tests/test_upload_mock_api.py
@@ -24,6 +24,7 @@ from ultimate_notion.rich_text import text
 
 import sphinx_notion._upload as notion_upload
 from sphinx_notion._upload import (
+    DiscussionsExistError,
     PageHasDatabasesError,
     PageHasSubpagesError,
 )
@@ -258,4 +259,29 @@ def test_upload_page_has_databases_error(
             cover_path=None,
             cover_url=None,
             cancel_on_discussion=False,
+        )
+
+
+def test_upload_discussions_exist_error(
+    notion_session: Session,
+) -> None:
+    """DiscussionsExistError raised when blocks to delete have discussions."""
+    with pytest.raises(
+        expected_exception=DiscussionsExistError,
+        match=r"1 block.*1 discussion",
+    ):
+        notion_upload.upload_to_notion(
+            session=notion_session,
+            blocks=[
+                UnoParagraph(
+                    text=text(text="Different content triggers sync"),
+                ),
+            ],
+            parent_page_id="cccc0000-0000-0000-0000-000000000001",
+            parent_database_id=None,
+            title="Upload Title",
+            icon=None,
+            cover_path=None,
+            cover_url=None,
+            cancel_on_discussion=True,
         )


### PR DESCRIPTION
Adds a mock API upload integration test asserting DiscussionsExistError is raised when deletion would affect blocks with discussions.

Also imports DiscussionsExistError in the test module for that assertion.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change that tightens coverage around an existing error condition; no production logic is modified.
> 
> **Overview**
> Adds a new WireMock-backed upload integration test that asserts `upload_to_notion(..., cancel_on_discussion=True)` raises `DiscussionsExistError` when a sync would delete blocks that have discussions, including a regex check on the error message.
> 
> Updates the test module imports to include `DiscussionsExistError`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b312b4dde7c998a78772532f8bf9e9fe6fd65631. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->