### PR TITLE
Adamtheturtle/cover url comment

### DIFF
--- a/tests/test_upload_mock_api.py
+++ b/tests/test_upload_mock_api.py
@@ -67,16 +67,14 @@ def _count_wiremock_requests(
     *,
     base_url: str,
     method: str,
-    url_path: str | None = None,
-    body_contains: str | None = None,
+    url_path: str,
     body_patterns: list[dict[str, str]] | None = None,
 ) -> int:
     """Count matching requests captured by WireMock."""
-    request_body: dict[str, object] = {"method": method}
-    if url_path is not None:
-        request_body["urlPath"] = url_path
-    if body_contains is not None:
-        request_body["bodyPatterns"] = [{"contains": body_contains}]
+    request_body: dict[str, object] = {
+        "method": method,
+        "urlPath": url_path,
+    }
     if body_patterns is not None:
         request_body["bodyPatterns"] = body_patterns
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Test-only changes that refine assertions and add coverage around cover upload request shapes; no production behavior is modified.
> 
> **Overview**
> Tightens the WireMock upload integration tests by generating a unique `upload_title` per run and relaxing title assertions to avoid cross-test collisions.
> 
> Adds request-body matching to `_count_wiremock_requests`, introduces `_page_update_url_path`, and updates/extends cover-related tests to assert the expected Notion API calls were made for both external `cover_url` and local `cover_path` uploads (including `file_uploads` create/send and page `PATCH`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ec1f93c1016b2630be44a15fca268a631113a226. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->