### PR TITLE
Extract WireMock request counter to shared test helper

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -342,6 +342,7 @@ plugins = [
 
 [tool.pyrefly]
 errors.non-exhaustive-match = "error"
+search-path = [ "." ]
 
 [tool.pyright]
 enableTypeIgnoreComments = false

--- a/tests/_wiremock.py
+++ b/tests/_wiremock.py
@@ -1,0 +1,25 @@
+"""WireMock test helpers."""
+
+import requests
+
+
+def count_wiremock_requests(
+    *,
+    base_url: str,
+    method: str,
+    url_path: str,
+) -> int:
+    """Count matching requests captured by WireMock."""
+    payload = {
+        "method": method,
+        "urlPath": url_path,
+    }
+    response = requests.post(
+        url=f"{base_url}/__admin/requests/count",
+        json=payload,
+        timeout=30,
+    )
+    response.raise_for_status()
+    count = response.json()["count"]
+    assert isinstance(count, int)
+    return count


### PR DESCRIPTION
## Summary

- Moves `_count_wiremock_requests` out of `test_upload_mock_api.py` into a new `tests/_wiremock.py` module, renamed to `count_wiremock_requests`
- The shared helper is needed by the upcoming `test_publish.py` (PR #524), but the extraction is a self-contained refactoring with no behaviour change

## Test plan

- [ ] All existing tests pass (172 passed)
- [ ] `mypy` reports no issues on the changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only refactor that moves duplicated WireMock request-counting logic into a shared helper and adjusts config; minimal risk aside from potential import/path issues in the test suite.
> 
> **Overview**
> Extracts the WireMock request-counting utility into a new shared test helper `tests/_wiremock.py` (renamed to `count_wiremock_requests`) and updates `test_upload_mock_api.py` to use it.
> 
> Adds `search-path = [ "." ]` to the `pyproject.toml` `pyrefly` configuration to ensure the new test module is discoverable.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 66e4495fa5ab5dd7ce5bfd64d32777b742c9a276. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->