### PR TITLE
Suppress pyrefly missing-import false positive for tests._wiremock

### DIFF
--- a/spelling_private_dict.txt
+++ b/spelling_private_dict.txt
@@ -13,6 +13,7 @@ hardcodes
 href
 pragma
 preprocess
+pyrefly
 pyright
 reStructuredText
 recurse

--- a/tests/test_upload_mock_api.py
+++ b/tests/test_upload_mock_api.py
@@ -24,7 +24,7 @@ from sphinx_notion._upload import (
     PageHasDatabasesError,
     PageHasSubpagesError,
 )
-from tests._wiremock import (
+from tests._wiremock import (  # pyrefly: ignore[missing-import]
     count_wiremock_requests,
 )
 


### PR DESCRIPTION
## Summary

- Add `# pyrefly: ignore[missing-import]` to the `tests._wiremock` import in `test_upload_mock_api.py` to suppress a false positive from the pyrefly type checker
- Add `pyrefly` to the spelling private dictionary so the comment text isn't flagged by the spell checker

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only changes affecting type-checking and spell-check tooling, with no runtime behavior impact.
> 
> **Overview**
> Suppresses a `pyrefly` type-checker false positive by adding `# pyrefly: ignore[missing-import]` to the `tests._wiremock` import used by `test_upload_mock_api.py`.
> 
> Adds `pyrefly` to `spelling_private_dict.txt` so the new directive comment isn’t flagged by the spell checker.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 801bb1ce0556831b9b69606e4717d812eeaacb43. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->