### PR TITLE
Add missing @beartype decorators

### DIFF
--- a/src/sphinx_notion/__init__.py
+++ b/src/sphinx_notion/__init__.py
@@ -365,6 +365,7 @@ def _notion_mention_date_role(  # pylint: disable=too-many-positional-arguments
     return [node], []
 
 
+@beartype
 @dataclass
 class _TableStructure:
     """Structure information extracted from a table node."""

--- a/src/sphinx_notion/_upload.py
+++ b/src/sphinx_notion/_upload.py
@@ -34,6 +34,7 @@ _LOGGER = logging.getLogger(name=__name__)
 _FILE_BLOCK_TYPES = (UnoImage, UnoVideo, UnoAudio, UnoPDF, UnoFile)
 
 
+@beartype
 @dataclass(frozen=True, slots=True)
 class _MatchLengths:
     """Matching prefix/suffix lengths for block diffing."""
@@ -229,6 +230,7 @@ def _is_existing_equivalent(
     return existing_page_block == local_block
 
 
+@beartype
 def _get_uploaded_cover(
     *,
     page: Page,


### PR DESCRIPTION
## Summary
- Add @beartype decorator to _MatchLengths dataclass, _get_uploaded_cover function, and _TableStructure dataclass

## Test plan
- [ ] Run existing test suite to verify no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, mechanical decorator additions; behavior only changes by raising runtime type errors if callers pass invalid types.
> 
> **Overview**
> Adds missing `@beartype` runtime type-checking to `_TableStructure` in `__init__.py`, plus `_MatchLengths` and `_get_uploaded_cover()` in `_upload.py`, making these dataclasses/functions consistent with the rest of the module’s type enforcement.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a56762393befa75a3028105202d82b1a672478ac. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->