### PR TITLE
Use native pytest TOML configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -321,8 +321,8 @@ keep_full_version = true
 max_supported_python = "3.14"
 
 [tool.pytest]
-ini_options.xfail_strict = true
-ini_options.log_cli = true
+xfail_strict = true
+log_cli = true
 
 [tool.coverage]
 run.branch = true


### PR DESCRIPTION
## Summary
- Remove `ini_options.` prefix from pytest configuration keys under `[tool.pytest]`
- Uses the native TOML configuration format supported since pytest 9.0
- See: https://docs.pytest.org/en/stable/reference/customize.html#pyproject-toml

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Configuration-only change; risk is limited to pytest reading these options differently or requiring pytest >= 9.0.
> 
> **Overview**
> Updates `pyproject.toml` to use pytest’s native TOML keys by removing the `ini_options.` prefix under `[tool.pytest]` (e.g., `xfail_strict` and `log_cli`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7a9179cee6c0e720b0983532c38daba85928e14c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->