### PR TITLE
Use keyword-only parameters in tests

### DIFF
--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1980,6 +1980,7 @@ def test_image_with_alt_text_only(
 
 
 def test_literalinclude_without_caption(
+    *,
     make_app: Callable[..., SphinxTestApp],
     tmp_path: Path,
 ) -> None:
@@ -2507,6 +2508,7 @@ def test_cross_reference_token(
 
 
 def test_literalinclude_with_caption(
+    *,
     make_app: Callable[..., SphinxTestApp],
     tmp_path: Path,
 ) -> None:

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -94,6 +94,7 @@ def test_help(file_regression: FileRegressionFixture) -> None:
 
 
 def test_upload_success(
+    *,
     mock_api_base_url: str,
     notion_token: str,
     parent_page_id: str,
@@ -122,6 +123,7 @@ def test_upload_success(
 
 
 def test_upload_page_has_subpages_error(
+    *,
     mock_api_base_url: str,
     notion_token: str,
     tmp_path: Path,
@@ -144,6 +146,7 @@ def test_upload_page_has_subpages_error(
 
 
 def test_upload_page_has_databases_error(
+    *,
     mock_api_base_url: str,
     notion_token: str,
     tmp_path: Path,
@@ -166,6 +169,7 @@ def test_upload_page_has_databases_error(
 
 
 def test_upload_discussions_exist_error(
+    *,
     mock_api_base_url: str,
     notion_token: str,
     tmp_path: Path,

--- a/tests/test_upload_mock_api.py
+++ b/tests/test_upload_mock_api.py
@@ -44,6 +44,7 @@ def _file_upload_create_count(*, base_url: str) -> int:
 
 
 def test_upload_to_notion_with_wiremock(
+    *,
     notion_session: Session,
     parent_page_id: str,
 ) -> None:
@@ -71,6 +72,7 @@ def test_upload_to_notion_with_wiremock(
 
 
 def test_upload_deletes_and_replaces_changed_blocks(
+    *,
     mock_api_base_url: str,
     notion_session: Session,
     parent_page_id: str,
@@ -117,6 +119,7 @@ def test_upload_deletes_and_replaces_changed_blocks(
 
 
 def test_upload_with_icon(
+    *,
     notion_session: Session,
     parent_page_id: str,
 ) -> None:
@@ -141,6 +144,7 @@ def test_upload_with_icon(
 
 
 def test_upload_with_cover_url(
+    *,
     notion_session: Session,
     parent_page_id: str,
 ) -> None:
@@ -227,6 +231,7 @@ def test_upload_discussions_exist_error(
 
 
 def test_upload_with_database_parent(
+    *,
     notion_session: Session,
     mock_api_base_url: str,
 ) -> None:
@@ -265,6 +270,7 @@ def test_upload_with_database_parent(
 
 
 def test_upload_with_cover_path(
+    *,
     mock_api_base_url: str,
     notion_session: Session,
     parent_page_id: str,
@@ -302,6 +308,7 @@ def test_upload_with_cover_path(
 
 
 def test_upload_with_file_block(
+    *,
     notion_session: Session,
     parent_page_id: str,
     tmp_path: Path,
@@ -342,6 +349,7 @@ def test_upload_with_file_block(
 
 
 def test_upload_with_nested_file_block(
+    *,
     notion_session: Session,
     parent_page_id: str,
     tmp_path: Path,
@@ -385,6 +393,7 @@ def test_upload_with_nested_file_block(
 
 
 def test_upload_prefix_suffix_matching(
+    *,
     mock_api_base_url: str,
     notion_session: Session,
 ) -> None:
@@ -430,6 +439,7 @@ def test_upload_prefix_suffix_matching(
 
 
 def test_upload_file_block_name_mismatch(
+    *,
     notion_session: Session,
     mock_api_base_url: str,
     tmp_path: Path,
@@ -467,6 +477,7 @@ def test_upload_file_block_name_mismatch(
 
 
 def test_upload_file_block_caption_mismatch(
+    *,
     notion_session: Session,
     mock_api_base_url: str,
     tmp_path: Path,
@@ -502,6 +513,7 @@ def test_upload_file_block_caption_mismatch(
 
 
 def test_upload_file_block_external_url(
+    *,
     notion_session: Session,
     mock_api_base_url: str,
 ) -> None:
@@ -534,6 +546,7 @@ def test_upload_file_block_external_url(
 
 
 def test_upload_file_block_existing_is_external(
+    *,
     notion_session: Session,
     mock_api_base_url: str,
     tmp_path: Path,
@@ -566,6 +579,7 @@ def test_upload_file_block_existing_is_external(
 
 
 def test_upload_matching_parent_blocks(
+    *,
     mock_api_base_url: str,
     notion_session: Session,
 ) -> None:
@@ -610,6 +624,7 @@ def test_upload_matching_parent_blocks(
 
 
 def test_upload_parent_block_different_children_count(
+    *,
     mock_api_base_url: str,
     notion_session: Session,
 ) -> None:


### PR DESCRIPTION
## Summary
- Enforce keyword-only arguments (using `*`) in test functions that accept multiple parameters
- This improves call-site clarity and prevents accidental positional argument errors

## Test plan
- [ ] Verify tests still pass

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes that adjust function signatures without altering production code paths.
> 
> **Overview**
> Refactors several pytest test functions to enforce **keyword-only parameters** by adding `*` to their signatures in `tests/test_integration.py`, `tests/test_upload.py`, and `tests/test_upload_mock_api.py`.
> 
> No runtime behavior changes are introduced; this is a test-only signature hardening to prevent accidental positional argument usage and improve readability.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4a0a78272ec85572ed928e2edec23bc016c7cda8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->