### PR TITLE
Add @beartype to test helper functions

### DIFF
--- a/tests/_wiremock.py
+++ b/tests/_wiremock.py
@@ -1,8 +1,10 @@
 """WireMock test helpers."""
 
 import requests
+from beartype import beartype
 
 
+@beartype
 def count_wiremock_requests(
     *,
     base_url: str,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,6 +21,7 @@ from ultimate_notion import Session
 pytest_plugins = "sphinx.testing.fixtures"  # pylint: disable=invalid-name
 
 
+@beartype
 @retry(
     stop=stop_after_delay(max_delay=30),
     wait=wait_fixed(wait=0.1),
@@ -35,6 +36,7 @@ def _wait_for_wiremock(*, base_url: str) -> None:
     response.raise_for_status()
 
 
+@beartype
 def _upload_wiremock_mappings(*, base_url: str, mappings_path: Path) -> None:
     """Upload mappings JSON to a WireMock instance."""
     with mappings_path.open(encoding="utf-8") as mappings_file:
@@ -115,6 +117,7 @@ def fixture_parent_page_id() -> str:
     return "59833787-2cf9-4fdf-8782-e53db20768a5"
 
 
+@beartype
 def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
     """
     Apply the ``beartype`` decorator to all collected test


### PR DESCRIPTION
## Summary
- Add `@beartype` decorator to non-fixture test helper functions that were missing runtime type checking
- Affected helpers: `count_wiremock_requests`, `_wait_for_wiremock`, `_upload_wiremock_mappings`, `pytest_collection_modifyitems`

## Test plan
- [ ] CI passes with existing tests

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change that adds runtime type checking; risk is limited to potentially surfacing new type errors and causing previously-passing tests to fail.
> 
> **Overview**
> Adds `@beartype` runtime type checking to WireMock-related test helpers (`count_wiremock_requests`, `_wait_for_wiremock`, `_upload_wiremock_mappings`) and to `pytest_collection_modifyitems`.
> 
> This increases enforcement of annotated types during test execution without changing production code paths.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 196212ea74fda27e9206aff32cf56c3b80c3ebe8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->