### PR TITLE
Bump doccmd to 2026.3.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ optional-dependencies.dev = [
     "check-manifest==0.51",
     "deptry==0.24.0",
     "doc8==2.0.0",
-    "doccmd==2026.2.26",
+    "doccmd==2026.3.1",
     "docker==7.1.0",
     "freezegun==1.5.5",
     "furo==2025.12.19",


### PR DESCRIPTION
Bump doccmd dependency to latest version.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates a pinned dev-only dependency version in `pyproject.toml`, with no runtime code changes.
> 
> **Overview**
> Bumps the pinned `doccmd` *dev dependency* in `pyproject.toml` from `2026.2.26` to `2026.3.1`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2afef01fbe0b9d2b7bef81c18f2084d8367cdaf2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->