### PR TITLE
Pin pydantic <2.13 to fix ultimate-notion user parsing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,10 @@ dependencies = [
     "click>=8.0.0",
     "cloup>=3.0.0",
     "docutils>=0.21",
+    # Pin pydantic to <2.13 to work around
+    # https://github.com/ultimate-notion/ultimate-notion/issues/189 -
+    # pydantic 2.13 breaks ultimate-notion's parsing of Notion user objects.
+    "pydantic<2.13",
     "requests>=2.32.5",
     # Pin Sphinx to <9 to avoid
     # https://github.com/sphinx-toolbox/sphinx-toolbox/issues/201
@@ -312,6 +316,9 @@ pep621_dev_dependency_groups = [
     "release",
     "sample",
 ]
+# pydantic is pinned to work around an ultimate-notion incompatibility,
+# not imported directly.
+per_rule_ignores = { DEP002 = [ "pydantic" ] }
 
 [tool.pyproject-fmt]
 indent = 4


### PR DESCRIPTION
## Summary
- Pins `pydantic<2.13` to work around [ultimate-notion/ultimate-notion#189](https://github.com/ultimate-notion/ultimate-notion/issues/189) — pydantic 2.13 breaks ultimate-notion's parsing of Notion user objects
- Adds `pydantic` to deptry's `DEP002` ignore list since it's not imported directly

## Test plan
- [x] All 203 tests pass
- [x] mypy clean
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: dependency metadata-only change that constrains `pydantic` versions and adjusts deptry linting, with no runtime logic modifications.
> 
> **Overview**
> Pins **`pydantic<2.13`** in `pyproject.toml` to work around an `ultimate-notion` incompatibility where `pydantic` 2.13 breaks parsing of Notion user objects.
> 
> Updates deptry config to *ignore* `DEP002` for `pydantic` since it’s a compatibility pin rather than a directly imported dependency.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b1f693105b885ac03d4314cb2cbbb7e70c9db28b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->