### PR TITLE
chore: use deptry optional_dependencies_dev_groups

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -311,7 +311,7 @@ ignore = [
 ]
 
 [tool.deptry]
-pep621_dev_dependency_groups = [
+optional_dependencies_dev_groups = [
     "dev",
     "release",
     "sample",


### PR DESCRIPTION
Renames `pep621_dev_dependency_groups` to `optional_dependencies_dev_groups` for deptry 0.25+.

This removes deprecation warnings; the old key may be removed in a future deptry release.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a configuration-only change that updates the `deptry` setting key to the newer `optional_dependencies_dev_groups`, affecting only dependency-check tooling behavior.
> 
> **Overview**
> Updates the `deptry` configuration in `pyproject.toml` by renaming `pep621_dev_dependency_groups` to `optional_dependencies_dev_groups` while keeping the same dev groups (`dev`, `release`, `sample`). This aligns the config with newer `deptry` versions and removes deprecation warnings without changing runtime dependencies.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 535a4fa06821c305cdec4fe6fb13182ac4418179. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->