### PR TITLE
Use pytest-beartype-tests plugin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,6 +78,7 @@ optional-dependencies.dev = [
     "pyright==1.1.408",
     "pyroma==5.0.1",
     "pytest==9.0.3",
+    "pytest-beartype-tests==2026.4.19.1",
     "pytest-cov==7.1.0",
     "pytest-regressions==2.10.0",
     "pyyaml==6.0.3",
@@ -99,7 +100,6 @@ optional-dependencies.dev = [
     "wiremock-mock==2026.3.2.1",
     "yamlfix==1.19.1",
     "zizmor==1.24.1",
-    "pytest-beartype-tests==2026.4.19.1",
 ]
 optional-dependencies.release = [ "check-wheel-contents==0.6.3" ]
 optional-dependencies.sample = [
@@ -108,6 +108,9 @@ optional-dependencies.sample = [
 urls.Source = "https://github.com/adamtheturtle/sphinx-notionbuilder"
 scripts.notion-upload = "_notion_scripts.upload:main"
 scripts.upload-files = "_notion_scripts.upload_files:main"
+
+[dependency-groups]
+dev = []
 
 [tool.setuptools]
 zip-safe = false
@@ -462,6 +465,3 @@ exclude = [ ".venv" ]
 [tool.yamlfix]
 section_whitelines = 1
 whitelines = 1
-
-[dependency-groups]
-dev = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,6 +99,7 @@ optional-dependencies.dev = [
     "wiremock-mock==2026.3.2.1",
     "yamlfix==1.19.1",
     "zizmor==1.24.1",
+    "pytest-beartype-tests==2026.4.19.1",
 ]
 optional-dependencies.release = [ "check-wheel-contents==0.6.3" ]
 optional-dependencies.sample = [
@@ -396,7 +397,6 @@ ignore_path = [
 ignore_names = [
     # pytest configuration
     "pytest_collect_file",
-    "pytest_collection_modifyitems",
     "pytest_plugins",
     "pytestmark",
     # pytest fixtures - we name fixtures like this for this purpose
@@ -462,3 +462,6 @@ exclude = [ ".venv" ]
 [tool.yamlfix]
 section_whitelines = 1
 whitelines = 1
+
+[dependency-groups]
+dev = []

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,7 +8,6 @@ from uuid import uuid4
 
 import pytest
 import respx
-from beartype import beartype
 from ultimate_notion import Session
 from wiremock_mock import add_wiremock_to_respx
 
@@ -82,15 +81,3 @@ def fixture_notion_session_fixture(
 def fixture_parent_page_id() -> str:
     """The page ID used by the mock API fixtures."""
     return "59833787-2cf9-4fdf-8782-e53db20768a5"
-
-
-@beartype
-def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
-    """
-    Apply the ``beartype`` decorator to all collected test
-    functions.
-    """
-    for item in items:
-        # All our tests are functions, for now
-        assert isinstance(item, pytest.Function)
-        item.obj = beartype(obj=item.obj)


### PR DESCRIPTION
This PR adds the [`pytest-beartype-tests`](https://github.com/adamtheturtle/pytest-beartype-tests) dev dependency and removes redundant `pytest_collection_modifyitems` / `@beartype` wiring from conftest where it duplicated the plugin.

The plugin registers via `pytest11` and applies `@beartype` to collected test functions, matching the previous local hook behavior (see the [upstream README](https://github.com/adamtheturtle/pytest-beartype-tests)).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because changes are limited to dev dependencies and pytest configuration; main impact is how tests are decorated/validated at collection time.
> 
> **Overview**
> Moves test-time `beartype` enforcement from a local `pytest_collection_modifyitems` hook in `tests/conftest.py` to the `pytest-beartype-tests` plugin by adding it to dev dependencies and deleting the redundant hook/import.
> 
> Cleans up config by removing `pytest_collection_modifyitems` from `vulture` ignore names and adding an empty `[dependency-groups]` `dev` section in `pyproject.toml`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ecddf8ea76288cf61f7efe4c341a50e072d91946. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->