### PR TITLE
Use pytest-beartype-tests plugin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,6 +78,7 @@ optional-dependencies.dev = [
     "pyright==1.1.408",
     "pyroma==5.0.1",
     "pytest==9.0.3",
+    "pytest-beartype-tests",
     "pytest-cov==7.1.0",
     "pytest-regressions==2.10.0",
     "pyyaml==6.0.3",
@@ -99,7 +100,6 @@ optional-dependencies.dev = [
     "wiremock-mock==2026.3.2.1",
     "yamlfix==1.19.1",
     "zizmor==1.24.1",
-    "pytest-beartype-tests==2026.4.19.1",
 ]
 optional-dependencies.release = [ "check-wheel-contents==0.6.3" ]
 optional-dependencies.sample = [
@@ -108,6 +108,9 @@ optional-dependencies.sample = [
 urls.Source = "https://github.com/adamtheturtle/sphinx-notionbuilder"
 scripts.notion-upload = "_notion_scripts.upload:main"
 scripts.upload-files = "_notion_scripts.upload_files:main"
+
+[dependency-groups]
+dev = []
 
 [tool.setuptools]
 zip-safe = false
@@ -128,6 +131,9 @@ bdist_wheel.universal = true
 #
 # Code to match this is in ``conf.py``.
 version_scheme = "post-release"
+
+[tool.uv]
+sources.pytest-beartype-tests = { git = "https://github.com/adamtheturtle/pytest-beartype-tests.git", rev = "bc81d99" }
 
 [tool.ruff]
 line-length = 79
@@ -462,6 +468,3 @@ exclude = [ ".venv" ]
 [tool.yamlfix]
 section_whitelines = 1
 whitelines = 1
-
-[dependency-groups]
-dev = []


### PR DESCRIPTION
This PR adds the [`pytest-beartype-tests`](https://github.com/adamtheturtle/pytest-beartype-tests) dev dependency and removes redundant `pytest_collection_modifyitems` wiring from conftest where it duplicated the plugin.

The dependency is pinned to [git `bc81d99`](https://github.com/adamtheturtle/pytest-beartype-tests/commit/bc81d99) via `[tool.uv.sources]` until a PyPI release includes the Sybil-safe plugin fix.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk since this only adjusts development/test dependencies and uv configuration, with no runtime or production code changes.
> 
> **Overview**
> This updates `pyproject.toml` to use the `pytest-beartype-tests` pytest plugin in the dev dependency set.
> 
> The plugin is sourced from a pinned git revision (`bc81d99`) via `[tool.uv.sources]`, and the prior explicit version pin is removed, along with a small reordering of the `[dependency-groups]` block.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d49d42f7ff45043f699c66fe220306d0aad8a34a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->