### PR TITLE
Pin pytest-beartype-tests to 2026.4.20

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,7 +78,7 @@ optional-dependencies.dev = [
     "pyright==1.1.408",
     "pyroma==5.0.1",
     "pytest==9.0.3",
-    "pytest-beartype-tests==2026.4.19.1",
+    "pytest-beartype-tests==2026.4.20",
     "pytest-cov==7.1.0",
     "pytest-regressions==2.10.0",
     "pyyaml==6.0.3",


### PR DESCRIPTION
Pin `pytest-beartype-tests` to PyPI [`2026.4.20`](https://pypi.org/project/pytest-beartype-tests/2026.4.20/), which includes the Sybil-safe plugin change, and drop the temporary `[tool.uv.sources]` git override.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk dependency pin update limited to dev/test tooling with no runtime code changes.
> 
> **Overview**
> Updates the dev dependency pin for `pytest-beartype-tests` from `2026.4.19.1` to `2026.4.20` in `pyproject.toml`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a7de62b1295355eda6a9e7c914f326e4cbd8517. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->