### PR TITLE
Bump Sphinx to v9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,13 +43,11 @@ dependencies = [
     # pydantic 2.13 breaks ultimate-notion's parsing of Notion user objects.
     "pydantic<2.13",
     "requests>=2.32.5",
-    # Pin Sphinx to <9 to avoid
-    # https://github.com/sphinx-toolbox/sphinx-toolbox/issues/201
-    "sphinx>=8.2.3,<9",
+    "sphinx>=9",
     "sphinx-iframes>=1.1.0",
     "sphinx-immaterial>=0.13.7",
     "sphinx-simplepdf>=1.6.0",
-    "sphinx-toolbox>=4.0.0",
+    "sphinx-toolbox>=4.2.0rc1",
     "sphinxcontrib-mermaid>=1.0.0",
     "sphinxcontrib-video>=0.4.0",
     "sphinxnotes-strike>=2.0",


### PR DESCRIPTION
## Summary
- Drop the `sphinx<9` pin and require `sphinx>=9`.
- Bump `sphinx-toolbox` to `>=4.2.0rc1`, the prerelease that adds Sphinx 9 support per [sphinx-toolbox#201](https://github.com/sphinx-toolbox/sphinx-toolbox/issues/201#issuecomment-4313483053).

## Test plan
- [x] `uv run pytest --cov --cov-branch` (203 passed)
- [x] `uv run mypy .`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Upgrades a core documentation/build dependency to a new major version and moves `sphinx-toolbox` to a release candidate, which could introduce build or extension compatibility issues.
> 
> **Overview**
> This PR updates project dependencies to **drop the `sphinx<9` pin and require `sphinx>=9`**.
> 
> To maintain compatibility with Sphinx 9, it also bumps `sphinx-toolbox` from `>=4.0.0` to the **`>=4.2.0rc1`** prerelease that supports Sphinx 9.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 21dc5ab51f7a7d0a8474e797bbd756d7d4231f6a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->