### PR TITLE
Surface Cloudflare WAF blocks distinctly from Notion API 403s

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ dependencies = [
     "click>=8.0.0",
     "cloup>=3.0.0",
     "docutils>=0.21",
+    "notion-client>=2.3.0",
     # Pin pydantic to <2.13 to work around
     # https://github.com/ultimate-notion/ultimate-notion/issues/189 -
     # pydantic 2.13 breaks ultimate-notion's parsing of Notion user objects.

--- a/spelling_private_dict.txt
+++ b/spelling_private_dict.txt
@@ -1,6 +1,8 @@
 Args
 CLI
+Cloudflare
 SVG
+WAF
 WireMock
 autodoc
 autosummary

--- a/src/sphinx_notion/_upload.py
+++ b/src/sphinx_notion/_upload.py
@@ -68,6 +68,7 @@ def _block_serialize_for_api_patched(
 UnoObjAPIBlock.serialize_for_api = _block_serialize_for_api_patched  # type: ignore[assignment]  # ty: ignore[invalid-assignment]
 
 _FILE_BLOCK_TYPES = (UnoImage, UnoVideo, UnoAudio, UnoPDF, UnoFile)
+_HTTP_FORBIDDEN = 403
 
 
 @beartype
@@ -498,9 +499,9 @@ def upload_to_notion(  # noqa: C901, PLR0912, PLR0915
                 after=after_block,
             )
         except HTTPResponseError as exc:
-            if not exc.headers.get(key="content-type", default="").startswith(
-                "text/html"
-            ):
+            if exc.status != _HTTP_FORBIDDEN or not exc.headers.get(
+                key="content-type", default=""
+            ).startswith("text/html"):
                 raise
             raise CloudflareWAFBlockError from exc
     return page

--- a/src/sphinx_notion/_upload.py
+++ b/src/sphinx_notion/_upload.py
@@ -369,6 +369,10 @@ def upload_to_notion(  # noqa: C901, PLR0912, PLR0915
         PageHasDatabasesError: If the page has databases.
         DiscussionsExistError: If blocks to delete have discussions and
             cancel_on_discussion is True.
+        CloudflareWAFBlockError: If the append request is blocked by the
+            Cloudflare WAF before reaching Notion.
+        HTTPResponseError: If the append request fails with a non-HTML
+            error response.
     """
     parent: Page | Database
     if parent_page_id:

--- a/src/sphinx_notion/_upload.py
+++ b/src/sphinx_notion/_upload.py
@@ -97,6 +97,8 @@ class DiscussionsExistError(Exception):
 class CloudflareWAFBlockError(Exception):
     """Raised when a request is blocked by the Cloudflare WAF before
     reaching Notion.
+
+    To reproduce: include ``/etc/hosts`` in a document and upload it.
     """
 
     def __init__(self) -> None:

--- a/src/sphinx_notion/_upload.py
+++ b/src/sphinx_notion/_upload.py
@@ -15,6 +15,7 @@ from urllib.request import url2pathname
 
 import requests
 from beartype import beartype
+from notion_client.errors import HTTPResponseError
 from ultimate_notion import Emoji, ExternalFile, NotionFile, Session
 from ultimate_notion.blocks import PDF as UnoPDF  # noqa: N811
 from ultimate_notion.blocks import Audio as UnoAudio
@@ -91,6 +92,20 @@ class DiscussionsExistError(Exception):
     cancel_on_discussion
     is True.
     """
+
+
+class CloudflareWAFBlockError(Exception):
+    """Raised when a request is blocked by the Cloudflare WAF before
+    reaching Notion.
+    """
+
+    def __init__(self) -> None:
+        """Initialize with a diagnostic message."""
+        super().__init__(
+            "Request blocked by Cloudflare WAF before reaching Notion API. "
+            "Common triggers: path traversal, SQL keywords, XSS patterns, "
+            "JNDI strings. The Notion API did not receive this request."
+        )
 
 
 @beartype
@@ -471,8 +486,15 @@ def upload_to_notion(  # noqa: C901, PLR0912, PLR0915
         after_block = (
             existing_blocks[prefix_len - 1] if prefix_len > 0 else None
         )
-        page.append(
-            blocks=block_objs_with_uploaded_files,
-            after=after_block,
-        )
+        try:
+            page.append(
+                blocks=block_objs_with_uploaded_files,
+                after=after_block,
+            )
+        except HTTPResponseError as exc:
+            if not exc.headers.get(key="content-type", default="").startswith(
+                "text/html"
+            ):
+                raise
+            raise CloudflareWAFBlockError from exc
     return page

--- a/tests/test_upload_mock_api.py
+++ b/tests/test_upload_mock_api.py
@@ -1,12 +1,17 @@
 """Integration test for upload synchronization against a mock API."""
 
+import re
 from pathlib import Path
+from unittest.mock import patch
 
+import httpx
 import pytest
 import respx
+from notion_client.errors import HTTPResponseError
 from ultimate_notion import ExternalFile, Session
 from ultimate_notion.blocks import (
     BulletedItem,
+    ChildrenMixin,
     Divider,
 )
 from ultimate_notion.blocks import Image as UnoImage
@@ -18,6 +23,7 @@ from ultimate_notion.rich_text import text
 
 import sphinx_notion._upload as notion_upload
 from sphinx_notion._upload import (
+    CloudflareWAFBlockError,
     DiscussionsExistError,
     PageHasDatabasesError,
     PageHasSubpagesError,
@@ -670,3 +676,83 @@ def test_upload_parent_block_different_children_count(
     assert after_delete_count == before_delete_count + 1
     assert after_parent_append_count == before_parent_append_count + 1
     assert after_child_append_count == before_child_append_count + 1
+
+
+def _make_cloudflare_error() -> HTTPResponseError:
+    """Create an HTTPResponseError simulating a Cloudflare WAF block."""
+    response = httpx.Response(
+        status_code=403,
+        headers={"content-type": "text/html; charset=utf-8"},
+        content=b"<html><body>Access denied</body></html>",
+    )
+    return HTTPResponseError(response=response)
+
+
+def test_cloudflare_waf_block(
+    *,
+    notion_session: Session,
+    parent_page_id: str,
+) -> None:
+    """CloudflareWAFBlockError raised when response content-type is
+    text/html.
+    """
+    expected = (
+        "Request blocked by Cloudflare WAF before reaching Notion API. "
+        "Common triggers: path traversal, SQL keywords, XSS patterns, "
+        "JNDI strings. The Notion API did not receive this request."
+    )
+    with (
+        patch.object(
+            target=ChildrenMixin,
+            attribute="append",
+            side_effect=_make_cloudflare_error(),
+        ),
+        pytest.raises(
+            expected_exception=CloudflareWAFBlockError,
+            match=f"^{re.escape(pattern=expected)}$",
+        ),
+    ):
+        notion_upload.upload_to_notion(
+            session=notion_session,
+            blocks=[UnoParagraph(text=text(text="WAF trigger content"))],
+            parent_page_id=parent_page_id,
+            parent_database_id=None,
+            title="Upload Title",
+            icon=None,
+            cover_path=None,
+            cover_url=None,
+            cancel_on_discussion=False,
+        )
+
+
+def test_non_html_403_not_wrapped(
+    *,
+    notion_session: Session,
+    parent_page_id: str,
+) -> None:
+    """HTTPResponseError with non-HTML body is re-raised unchanged."""
+    response = httpx.Response(
+        status_code=403,
+        headers={"content-type": "application/json"},
+        content=b'{"code": "restricted_resource"}',
+    )
+    json_error = HTTPResponseError(response=response)
+    with (
+        patch.object(
+            target=ChildrenMixin,
+            attribute="append",
+            side_effect=json_error,
+        ),
+        pytest.raises(expected_exception=HTTPResponseError),
+    ):
+        notion_upload.upload_to_notion(
+            session=notion_session,
+            blocks=[UnoParagraph(text=text(text="Content"))],
+            parent_page_id=parent_page_id,
+            parent_database_id=None,
+            title="Upload Title",
+            icon=None,
+            cover_path=None,
+            cover_url=None,
+            cancel_on_discussion=False,
+        )

--- a/tests/test_upload_mock_api.py
+++ b/tests/test_upload_mock_api.py
@@ -678,12 +678,12 @@ def test_upload_parent_block_different_children_count(
     assert after_child_append_count == before_child_append_count + 1
 
 
-def _make_cloudflare_error() -> HTTPResponseError:
-    """Create an HTTPResponseError simulating a Cloudflare WAF block."""
+def _make_html_http_error(*, status_code: int) -> HTTPResponseError:
+    """Create an HTTPResponseError with an HTML response body."""
     response = httpx.Response(
-        status_code=403,
+        status_code=status_code,
         headers={"content-type": "text/html; charset=utf-8"},
-        content=b"<html><body>Access denied</body></html>",
+        content=b"<html><body>Error</body></html>",
     )
     return HTTPResponseError(response=response)
 
@@ -705,7 +705,7 @@ def test_cloudflare_waf_block(
         patch.object(
             target=ChildrenMixin,
             attribute="append",
-            side_effect=_make_cloudflare_error(),
+            side_effect=_make_html_http_error(status_code=403),
         ),
         pytest.raises(
             expected_exception=CloudflareWAFBlockError,
@@ -742,6 +742,35 @@ def test_non_html_403_not_wrapped(
             target=ChildrenMixin,
             attribute="append",
             side_effect=json_error,
+        ),
+        pytest.raises(expected_exception=HTTPResponseError),
+    ):
+        notion_upload.upload_to_notion(
+            session=notion_session,
+            blocks=[UnoParagraph(text=text(text="Content"))],
+            parent_page_id=parent_page_id,
+            parent_database_id=None,
+            title="Upload Title",
+            icon=None,
+            cover_path=None,
+            cover_url=None,
+            cancel_on_discussion=False,
+        )
+
+
+def test_non_403_html_not_wrapped(
+    *,
+    notion_session: Session,
+    parent_page_id: str,
+) -> None:
+    """HTTPResponseError with HTML body but non-403 status is re-
+    raised.
+    """
+    with (
+        patch.object(
+            target=ChildrenMixin,
+            attribute="append",
+            side_effect=_make_html_http_error(status_code=502),
         ),
         pytest.raises(expected_exception=HTTPResponseError),
     ):

--- a/tests/test_upload_mock_api.py
+++ b/tests/test_upload_mock_api.py
@@ -694,7 +694,7 @@ def test_cloudflare_waf_block(
     parent_page_id: str,
 ) -> None:
     """CloudflareWAFBlockError raised when response content-type is
-    text/html.
+    text/HTML.
     """
     expected = (
         "Request blocked by Cloudflare WAF before reaching Notion API. "


### PR DESCRIPTION
## Summary

- Adds `CloudflareWAFBlockError` exception raised when `page.append()` gets a 403 with a `text/html` response body, indicating the request was blocked by the Cloudflare WAF before reaching Notion's API.
- Re-raises plain `HTTPResponseError` unchanged for genuine Notion 403s (JSON body), so existing error handling is unaffected.
- Declares `notion-client` as a direct dependency in `pyproject.toml` since it is now imported directly.

## Test plan

- `test_cloudflare_waf_block`: verifies `CloudflareWAFBlockError` is raised with the exact expected message when the append response has `content-type: text/html`.
- `test_non_html_403_not_wrapped`: verifies a JSON-body 403 propagates as `HTTPResponseError` unchanged.

Closes #732

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds narrow error-wrapping around `page.append()` for a specific 403+HTML response and leaves other `HTTPResponseError` cases unchanged.
> 
> **Overview**
> **Distinguishes Cloudflare WAF blocks from real Notion API 403s during uploads.** `upload_to_notion()` now catches `HTTPResponseError` from `page.append()` and, when it’s a `403` with `content-type: text/html`, raises a new `CloudflareWAFBlockError` with a diagnostic message; all other errors are re-raised unchanged.
> 
> Adds `notion-client` as a direct dependency (now imported directly) and extends the mock-API integration tests to cover the new wrapping behavior (HTML 403 wrapped; JSON 403 and non-403 HTML not wrapped).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae0ac296377cc11d887a7502b90ec5ad62c6e212. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->