### PR TITLE
Bump mypy to 2.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ optional-dependencies.dev = [
     "freezegun==1.5.5",
     "furo==2025.12.19",
     "interrogate==1.7.0",
-    "mypy[faster-cache]==1.20.2",
+    "mypy[faster-cache]==2.0.0",
     "mypy-strict-kwargs==2026.1.12",
     "prek==0.3.13",
     "pydocstringformatter==0.7.5",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk functional impact since this only updates a dev-only type-checking dependency, but the major-version bump may introduce new/changed mypy diagnostics in CI and local workflows.
> 
> **Overview**
> Updates the dev tooling dependency `mypy[faster-cache]` from `1.20.2` to `2.0.0` in `pyproject.toml`, affecting type-checking behavior for contributors/CI without changing runtime dependencies.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 91b91decc2b5b520825d469abe169f3c2c09d4ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->