### PR TITLE
Enable mypy parallel workers in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -157,7 +157,7 @@ repos:
       - id: mypy
         name: mypy
         stages: [pre-push]
-        entry: uv run --extra=dev -m mypy
+        entry: uv run --extra=dev -m mypy --num-workers=4
         language: python
         types_or: [python, toml]
         pass_filenames: false
@@ -168,7 +168,8 @@ repos:
       - id: mypy-docs
         name: mypy-docs
         stages: [pre-push]
-        entry: uv run --extra=dev doccmd --no-write-to-file --language=python --command="mypy"
+        entry: uv run --extra=dev doccmd --no-write-to-file --language=python --command="mypy
+          --num-workers=4"
         language: python
         types_or: [markdown, rst]
         additional_dependencies:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -168,8 +168,9 @@ repos:
       - id: mypy-docs
         name: mypy-docs
         stages: [pre-push]
-        entry: uv run --extra=dev doccmd --no-write-to-file --language=python --command="mypy
-          --num-workers=4"
+        entry: >-
+          uv run --extra=dev doccmd --no-write-to-file --language=python
+          --command="mypy --num-workers=4"
         language: python
         types_or: [markdown, rst]
         additional_dependencies:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,7 @@ dependencies = [
 optional-dependencies.dev = [
     "actionlint-py==1.7.12.24",
     "anstrip==0.2.2",
+    "ast-serialize>=0.3.0",
     "check-manifest==0.51",
     "deptry==0.25.1",
     "doc8==2.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,6 @@ dependencies = [
 optional-dependencies.dev = [
     "actionlint-py==1.7.12.24",
     "anstrip==0.2.2",
-    "ast-serialize>=0.3.0",
     "check-manifest==0.51",
     "deptry==0.25.1",
     "doc8==2.0.0",


### PR DESCRIPTION
## Summary
- enable `mypy` pre-push hook parallelism with `--num-workers=4`
- update `mypy-docs` doccmd command to run `mypy --num-workers=4`
- add `ast-serialize>=0.3.0` to dev dependencies so mypy worker subprocesses run successfully

## Test plan
- [x] `uv run --extra=dev pre-commit validate-config`
- [x] `uv run --extra=dev -m mypy --num-workers=4`
- [x] `git push -u origin HEAD` (pre-push hooks passed)

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only tweaks pre-push hook command lines to speed up type checking; no runtime or production code changes.
> 
> **Overview**
> Speeds up pre-push type checking by running `mypy` with `--num-workers=4`.
> 
> Updates the `mypy-docs` hook to invoke `mypy --num-workers=4` via `doccmd` (with multiline YAML formatting) so doc type checks use the same parallelism.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e5ebe5d01918cf7c9a7221866d866d4ede6d3b94. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->