### PR TITLE
Add strict-kwargs pre-commit hook in fix mode

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -301,7 +301,6 @@ repos:
           - *uv_version
         stages: [pre-commit]
 
-
       - id: strict-kwargs-fix
         name: strict-kwargs
         entry: uv run --extra=dev strict-kwargs fix

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,6 +12,7 @@ ci:
   skip:
     - actionlint
     - sphinx-lint
+    - strict-kwargs-fix
     - check-manifest
     - deptry
     - doc8
@@ -299,6 +300,17 @@ repos:
         additional_dependencies:
           - *uv_version
         stages: [pre-commit]
+
+
+      - id: strict-kwargs-fix
+        name: strict-kwargs
+        entry: uv run --extra=dev strict-kwargs fix
+        language: python
+        types_or: [python]
+        additional_dependencies:
+          - *uv_version
+        stages: [pre-commit]
+        require_serial: true
 
       - id: doc8
         name: doc8

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,8 @@ dependencies = [
     "sphinxnotes-strike>=2.0",
     "ultimate-notion>=0.9.6",
 ]
-optional-dependencies.dev = [    "actionlint-py==1.7.12.24",
+optional-dependencies.dev = [
+    "actionlint-py==1.7.12.24",
     "anstrip==0.2.2",
     "check-manifest==0.51",
     "deptry==0.25.1",
@@ -99,6 +100,7 @@ optional-dependencies.dev = [    "actionlint-py==1.7.12.24",
     "wiremock-mock==2026.3.2.1",
     "yamlfix==1.19.1",
     "zizmor==1.25.2",
+
 ]
 optional-dependencies.release = [ "check-wheel-contents==0.6.3" ]
 optional-dependencies.sample = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,7 +92,7 @@ optional-dependencies.dev = [
     "sphinx-substitution-extensions==2026.1.12",
     "sphinxcontrib-spelling==8.0.2",
     "sphinxcontrib-text-styles==0.2.1",
-    "strict-kwargs==2026.5.18",
+    "strict-kwargs==2026.5.18.post1",
     "ty==0.0.37",
     "types-docutils==0.22.3.20260508",
     "types-requests==2.33.0.20260513",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,8 +54,7 @@ dependencies = [
     "sphinxnotes-strike>=2.0",
     "ultimate-notion>=0.9.6",
 ]
-optional-dependencies.dev = [
-    "actionlint-py==1.7.12.24",
+optional-dependencies.dev = [    "actionlint-py==1.7.12.24",
     "anstrip==0.2.2",
     "check-manifest==0.51",
     "deptry==0.25.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,6 +92,7 @@ optional-dependencies.dev = [
     "sphinx-substitution-extensions==2026.1.12",
     "sphinxcontrib-spelling==8.0.2",
     "sphinxcontrib-text-styles==0.2.1",
+    "strict-kwargs==2026.5.18",
     "ty==0.0.37",
     "types-docutils==0.22.3.20260508",
     "types-requests==2.33.0.20260513",
@@ -364,6 +365,14 @@ report.exclude_also = [
 report.show_missing = true
 
 [tool.mypy_strict_kwargs]
+# ``url2pathname`` had its parameter renamed from ``pathname`` to ``url`` in
+# Python 3.14 (https://github.com/python/cpython/issues/127065), so we cannot
+# use a keyword argument that works across all supported Python versions.
+# On Windows, ``urllib.request`` re-exports ``url2pathname`` from ``nturl2path``,
+# so mypy resolves the fullname as ``nturl2path.url2pathname`` on that platform.
+ignore_names = [ "nturl2path.url2pathname", "urllib.request.url2pathname" ]
+
+[tool.strict_kwargs]
 # ``url2pathname`` had its parameter renamed from ``pathname`` to ``url`` in
 # Python 3.14 (https://github.com/python/cpython/issues/127065), so we cannot
 # use a keyword argument that works across all supported Python versions.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,7 +100,6 @@ optional-dependencies.dev = [
     "wiremock-mock==2026.3.2.1",
     "yamlfix==1.19.1",
     "zizmor==1.25.2",
-
 ]
 optional-dependencies.release = [ "check-wheel-contents==0.6.3" ]
 optional-dependencies.sample = [

--- a/src/sphinx_notion/__init__.py
+++ b/src/sphinx_notion/__init__.py
@@ -714,7 +714,7 @@ def _create_rich_text_from_children(*, node: nodes.Element) -> Text:
     rich_text = Text.from_plain_text(text="")
 
     for child in node.children:
-        new_text = _process_rich_text_node(child)
+        new_text = _process_rich_text_node(node=child)
         rich_text += new_text
 
     return rich_text
@@ -1049,7 +1049,7 @@ def _(
         and node.children[0].attributes.get("classes", []) == ["rest-example"]
     ):
         return _process_node_to_blocks(
-            node.children[0],
+            node=node.children[0],
             section_level=section_level,
         )
 
@@ -1066,10 +1066,10 @@ def _(
 ) -> list[Block]:
     """Process block quote nodes by creating Notion Quote blocks."""
     first_child = node.children[0]
-    rich_text = _process_rich_text_node(first_child)
+    rich_text = _process_rich_text_node(node=first_child)
     quote = UnoQuote(text=rich_text)
     for child in node.children[1:]:
-        blocks = _process_node_to_blocks(child, section_level=section_level)
+        blocks = _process_node_to_blocks(node=child, section_level=section_level)
         quote.append(blocks=blocks)
 
     return [quote]
@@ -1111,7 +1111,7 @@ def _(
 
             for child in list_item.children[1:]:
                 child_blocks = _process_node_to_blocks(
-                    child,
+                    node=child,
                     section_level=section_level,
                 )
                 bulleted_item_block.append(blocks=child_blocks)
@@ -1132,7 +1132,7 @@ def _(
 
             for child in list_item.children[2:]:
                 child_blocks = _process_node_to_blocks(
-                    child,
+                    node=child,
                     section_level=section_level,
                 )
                 todo_item_block.append(blocks=child_blocks)
@@ -1163,7 +1163,7 @@ def _(
 
             for child in list_item.children[1:]:
                 child_blocks = _process_node_to_blocks(
-                    child,
+                    node=child,
                     section_level=section_level,
                 )
                 block.append(blocks=child_blocks)
@@ -1184,7 +1184,7 @@ def _(
 
             for child in list_item.children[2:]:
                 child_blocks = _process_node_to_blocks(
-                    child,
+                    node=child,
                     section_level=section_level,
                 )
                 todo_item_block.append(blocks=child_blocks)
@@ -1247,7 +1247,7 @@ def _(
 
         for child in definition_node.children:
             child_blocks = _process_node_to_blocks(
-                child,
+                node=child,
                 section_level=section_level,
             )
             bulleted_item.append(blocks=child_blocks)
@@ -1350,7 +1350,7 @@ def _create_admonition_callout(
     for child in children_to_process:
         block.append(
             blocks=_process_node_to_blocks(
-                child,
+                node=child,
                 section_level=1,
             )
         )
@@ -1551,7 +1551,7 @@ def _(
     for child in content_children:
         block.append(
             blocks=_process_node_to_blocks(
-                child,
+                node=child,
                 section_level=1,
             )
         )
@@ -1575,7 +1575,7 @@ def _(
     for child in node.children:
         toggle_block.append(
             blocks=_process_node_to_blocks(
-                child,
+                node=child,
                 section_level=1,
             )
         )
@@ -1652,7 +1652,7 @@ def _(
             )
             continue
         child_blocks = _process_node_to_blocks(
-            child, section_level=section_level
+            node=child, section_level=section_level
         )
         blocks.extend(child_blocks)
     return blocks
@@ -1844,7 +1844,7 @@ def _(
     blocks: list[Block] = []
     for child in node.children:
         child_blocks = _process_node_to_blocks(
-            child, section_level=section_level
+            node=child, section_level=section_level
         )
         blocks.extend(child_blocks)
     return blocks
@@ -1888,12 +1888,12 @@ def _process_rest_example_container(
     rst_source_node = node.children[0]
     assert isinstance(rst_source_node, nodes.literal_block)
     output_nodes = node.children[1:]
-    code_blocks = _process_node_to_blocks(rst_source_node, section_level=1)
+    code_blocks = _process_node_to_blocks(node=rst_source_node, section_level=1)
 
     output_blocks: list[Block] = []
     for output_node in output_nodes:
         output_blocks.extend(
-            _process_node_to_blocks(output_node, section_level=section_level)
+            _process_node_to_blocks(node=output_node, section_level=section_level)
         )
 
     code_callout = UnoCallout(text=text(text="Code"))
@@ -2064,7 +2064,7 @@ def _(
     blocks: list[Block] = []
     for child in node.children:
         child_blocks = _process_node_to_blocks(
-            child, section_level=section_level
+            node=child, section_level=section_level
         )
         blocks.extend(child_blocks)
     return blocks
@@ -2085,7 +2085,7 @@ def _(
     blocks: list[Block] = []
     for child in node.children:
         child_blocks = _process_node_to_blocks(
-            child, section_level=section_level
+            node=child, section_level=section_level
         )
         blocks.extend(child_blocks)
     return blocks
@@ -2117,7 +2117,7 @@ def _(
             for content_child in child.children:
                 content_blocks.extend(
                     _process_node_to_blocks(
-                        content_child,
+                        node=content_child,
                         section_level=section_level,
                     )
                 )
@@ -2152,7 +2152,7 @@ class NotionTranslator(NodeVisitor):
             return
 
         blocks = _process_node_to_blocks(
-            node,
+            node=node,
             section_level=self._section_level,
         )
         self._blocks.extend(blocks)

--- a/src/sphinx_notion/__init__.py
+++ b/src/sphinx_notion/__init__.py
@@ -714,7 +714,7 @@ def _create_rich_text_from_children(*, node: nodes.Element) -> Text:
     rich_text = Text.from_plain_text(text="")
 
     for child in node.children:
-        new_text = _process_rich_text_node(node=child)
+        new_text = _process_rich_text_node(child)
         rich_text += new_text
 
     return rich_text
@@ -1049,7 +1049,7 @@ def _(
         and node.children[0].attributes.get("classes", []) == ["rest-example"]
     ):
         return _process_node_to_blocks(
-            node=node.children[0],
+            node.children[0],
             section_level=section_level,
         )
 
@@ -1066,10 +1066,10 @@ def _(
 ) -> list[Block]:
     """Process block quote nodes by creating Notion Quote blocks."""
     first_child = node.children[0]
-    rich_text = _process_rich_text_node(node=first_child)
+    rich_text = _process_rich_text_node(first_child)
     quote = UnoQuote(text=rich_text)
     for child in node.children[1:]:
-        blocks = _process_node_to_blocks(node=child, section_level=section_level)
+        blocks = _process_node_to_blocks(child, section_level=section_level)
         quote.append(blocks=blocks)
 
     return [quote]
@@ -1111,7 +1111,7 @@ def _(
 
             for child in list_item.children[1:]:
                 child_blocks = _process_node_to_blocks(
-                    node=child,
+                    child,
                     section_level=section_level,
                 )
                 bulleted_item_block.append(blocks=child_blocks)
@@ -1132,7 +1132,7 @@ def _(
 
             for child in list_item.children[2:]:
                 child_blocks = _process_node_to_blocks(
-                    node=child,
+                    child,
                     section_level=section_level,
                 )
                 todo_item_block.append(blocks=child_blocks)
@@ -1163,7 +1163,7 @@ def _(
 
             for child in list_item.children[1:]:
                 child_blocks = _process_node_to_blocks(
-                    node=child,
+                    child,
                     section_level=section_level,
                 )
                 block.append(blocks=child_blocks)
@@ -1184,7 +1184,7 @@ def _(
 
             for child in list_item.children[2:]:
                 child_blocks = _process_node_to_blocks(
-                    node=child,
+                    child,
                     section_level=section_level,
                 )
                 todo_item_block.append(blocks=child_blocks)
@@ -1247,7 +1247,7 @@ def _(
 
         for child in definition_node.children:
             child_blocks = _process_node_to_blocks(
-                node=child,
+                child,
                 section_level=section_level,
             )
             bulleted_item.append(blocks=child_blocks)
@@ -1350,7 +1350,7 @@ def _create_admonition_callout(
     for child in children_to_process:
         block.append(
             blocks=_process_node_to_blocks(
-                node=child,
+                child,
                 section_level=1,
             )
         )
@@ -1551,7 +1551,7 @@ def _(
     for child in content_children:
         block.append(
             blocks=_process_node_to_blocks(
-                node=child,
+                child,
                 section_level=1,
             )
         )
@@ -1575,7 +1575,7 @@ def _(
     for child in node.children:
         toggle_block.append(
             blocks=_process_node_to_blocks(
-                node=child,
+                child,
                 section_level=1,
             )
         )
@@ -1652,7 +1652,7 @@ def _(
             )
             continue
         child_blocks = _process_node_to_blocks(
-            node=child, section_level=section_level
+            child, section_level=section_level
         )
         blocks.extend(child_blocks)
     return blocks
@@ -1844,7 +1844,7 @@ def _(
     blocks: list[Block] = []
     for child in node.children:
         child_blocks = _process_node_to_blocks(
-            node=child, section_level=section_level
+            child, section_level=section_level
         )
         blocks.extend(child_blocks)
     return blocks
@@ -1888,12 +1888,12 @@ def _process_rest_example_container(
     rst_source_node = node.children[0]
     assert isinstance(rst_source_node, nodes.literal_block)
     output_nodes = node.children[1:]
-    code_blocks = _process_node_to_blocks(node=rst_source_node, section_level=1)
+    code_blocks = _process_node_to_blocks(rst_source_node, section_level=1)
 
     output_blocks: list[Block] = []
     for output_node in output_nodes:
         output_blocks.extend(
-            _process_node_to_blocks(node=output_node, section_level=section_level)
+            _process_node_to_blocks(output_node, section_level=section_level)
         )
 
     code_callout = UnoCallout(text=text(text="Code"))
@@ -2064,7 +2064,7 @@ def _(
     blocks: list[Block] = []
     for child in node.children:
         child_blocks = _process_node_to_blocks(
-            node=child, section_level=section_level
+            child, section_level=section_level
         )
         blocks.extend(child_blocks)
     return blocks
@@ -2085,7 +2085,7 @@ def _(
     blocks: list[Block] = []
     for child in node.children:
         child_blocks = _process_node_to_blocks(
-            node=child, section_level=section_level
+            child, section_level=section_level
         )
         blocks.extend(child_blocks)
     return blocks
@@ -2117,7 +2117,7 @@ def _(
             for content_child in child.children:
                 content_blocks.extend(
                     _process_node_to_blocks(
-                        node=content_child,
+                        content_child,
                         section_level=section_level,
                     )
                 )
@@ -2152,7 +2152,7 @@ class NotionTranslator(NodeVisitor):
             return
 
         blocks = _process_node_to_blocks(
-            node=node,
+            node,
             section_level=self._section_level,
         )
         self._blocks.extend(blocks)


### PR DESCRIPTION
## Summary
- Add the [strict-kwargs](https://github.com/adamtheturtle/strict-kwargs) pre-commit hook (`rev: 2026.5.18`) with `args: [fix]` so positional call arguments are rewritten to keyword form on commit.
- Skip the hook in pre-commit CI (builds from source and needs a Rust toolchain).
- Mirror `[tool.mypy_strict_kwargs]` into `[tool.strict_kwargs]` where custom ignore lists already exist.

## Test plan
- [ ] `pre-commit run strict-kwargs --all-files`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to developer tooling (pre-commit and dev dependencies), though the new hook can rewrite call sites on commit.
> 
> **Overview**
> Introduces a new local pre-commit hook `strict-kwargs-fix` that runs `strict-kwargs fix` (serially) to auto-rewrite calls to keyword-argument form, and skips this hook in pre-commit CI.
> 
> Adds `strict-kwargs` to the dev dependency set and mirrors existing ignore rules into a new `[tool.strict_kwargs]` section in `pyproject.toml`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 230dc1be83e71c6979fd4329a1cea0c583d2077d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->