### PR TITLE
chore(deps-dev): Bump doccmd from 2026.5.6 to 2026.5.16

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ optional-dependencies.dev = [
     "check-manifest==0.51",
     "deptry==0.25.1",
     "doc8==2.0.0",
-    "doccmd==2026.5.6",
+    "doccmd==2026.5.16",
     "freezegun==1.5.5",
     "furo==2025.12.19",
     "interrogate==1.7.0",
@@ -151,7 +151,7 @@ lint.ignore = [
     # We use asserts for type narrowing.
     "S101",
 ]
-lint.per-file-ignores."doccmd_*.py" = [
+lint.per-file-ignores."doccmd_*/doccmd_*.py" = [
     # Allow our chosen docstring line-style - pydocstringformatter handles
     # formatting but docstrings in docs may not match this style.
     "D200",
@@ -265,8 +265,7 @@ MESSAGES-CONTROL.disable = [
 # - conf.py is a Sphinx configuration file which requires lowercase global variable names.
 MESSAGES-CONTROL.per-file-ignores = [
     "docs/source/conf.py:invalid-name",
-    "docs/source/doccmd_*.py:invalid-name",
-    "doccmd_README_rst_*.py:invalid-name",
+    "doccmd_*/doccmd_*.py:invalid-name",
     "sample/conf.py:invalid-name",
     "sample_warnings/conf.py:invalid-name",
 ]


### PR DESCRIPTION
Fixes #758.

Bumps doccmd from 2026.5.6 to 2026.5.16.

doccmd 2026.5.16 isolates per-example temp files in a hash-named subdirectory (`doccmd_HASH/doccmd_*.py`) instead of placing them directly at the project root. This broke the `ruff` and `pylint` per-file-ignores patterns that suppress `invalid-name` and formatting warnings for generated documentation code examples.

## Changes

- Bump `doccmd` to `2026.5.16`
- Update ruff `per-file-ignores` from `doccmd_*.py` → `doccmd_*/doccmd_*.py`
- Update pylint `MESSAGES-CONTROL.per-file-ignores` from `docs/source/doccmd_*.py` and `doccmd_README_rst_*.py` → `doccmd_*/doccmd_*.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates a dev dependency and adjusts `ruff`/`pylint` ignore patterns so generated `doccmd` example files continue to be excluded from linting.
> 
> **Overview**
> Updates the dev dependency `doccmd` from `2026.5.6` to `2026.5.16`.
> 
> Adjusts `ruff` and `pylint` per-file ignore globs to match `doccmd`'s new output layout (`doccmd_*/doccmd_*.py`), preventing lint failures on generated documentation example files.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 99684b4423292235c1479c48d6420288495337a1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->