### PR TITLE
Ban dynamic builtins and typing.cast in lint config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -173,6 +173,7 @@ lint.per-file-ignores."tests/*.py" = [
 lint.unfixable = [
     "ERA001",
 ]
+lint.flake8-tidy-imports.banned-api."typing.cast".msg = "typing.cast is banned: use explicit type narrowing or a typed variable instead."
 lint.pydocstyle.convention = "google"
 
 [tool.pylint]
@@ -213,6 +214,17 @@ MASTER.load-plugins = [
 # Allow loading of arbitrary C extensions. Extensions are imported into the
 # active Python interpreter and may run arbitrary code.
 MASTER.unsafe-load-any-extension = false
+DEPRECATED_BUILTINS.bad-functions = [
+    # Use Pylint until Ruff can ban bare builtin calls, or until custom rules
+    # make this removable:
+    # https://github.com/astral-sh/ruff/issues/10079
+    # https://github.com/astral-sh/ruff/issues/970
+    "filter",
+    "getattr",
+    "hasattr",
+    "map",
+    "setattr",
+]
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option
 # multiple time (only on the command line, not in the configuration file where

--- a/src/sphinx_notion/_upload.py
+++ b/src/sphinx_notion/_upload.py
@@ -49,10 +49,10 @@ def _strip_archived_fields(*, data: dict[str, object]) -> None:
     for value in data.values():
         if not isinstance(value, dict):
             continue
-        children = cast("dict[str, object]", value).get("children")  # noqa: TID251
+        children = cast("dict[str, object]", value).get("children")
         if not isinstance(children, list):
             continue
-        for child in cast("list[dict[str, object]]", children):  # noqa: TID251
+        for child in cast("list[dict[str, object]]", children):
             _strip_archived_fields(data=child)
 
 

--- a/src/sphinx_notion/_upload.py
+++ b/src/sphinx_notion/_upload.py
@@ -49,14 +49,13 @@ def _strip_archived_fields(*, data: dict[str, object]) -> None:
     for value in data.values():
         if not isinstance(value, dict):
             continue
-        nested: dict[str, object] = value
-        children = nested.get("children")
-        if not isinstance(children, list):
+        children_object = value.get("children")
+        if not isinstance(children_object, list):
             continue
-        for child in children:
-            if not isinstance(child, dict):
+        for child_object in children_object:
+            if not isinstance(child_object, dict):
                 continue
-            _strip_archived_fields(data=child)
+            _strip_archived_fields(data=child_object)
 
 
 def _block_serialize_for_api_patched(

--- a/src/sphinx_notion/_upload.py
+++ b/src/sphinx_notion/_upload.py
@@ -9,7 +9,7 @@ from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 from functools import cache
 from pathlib import Path
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING
 from urllib.parse import urlparse
 from urllib.request import url2pathname
 
@@ -49,10 +49,13 @@ def _strip_archived_fields(*, data: dict[str, object]) -> None:
     for value in data.values():
         if not isinstance(value, dict):
             continue
-        children = cast("dict[str, object]", value).get("children")
+        nested: dict[str, object] = value
+        children = nested.get("children")
         if not isinstance(children, list):
             continue
-        for child in cast("list[dict[str, object]]", children):
+        for child in children:
+            if not isinstance(child, dict):
+                continue
             _strip_archived_fields(data=child)
 
 

--- a/src/sphinx_notion/_upload.py
+++ b/src/sphinx_notion/_upload.py
@@ -9,7 +9,7 @@ from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 from functools import cache
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast  # noqa: TID251
 from urllib.parse import urlparse
 from urllib.request import url2pathname
 
@@ -49,13 +49,11 @@ def _strip_archived_fields(*, data: dict[str, object]) -> None:
     for value in data.values():
         if not isinstance(value, dict):
             continue
-        children_object = value.get("children")
-        if not isinstance(children_object, list):
+        children = cast("dict[str, object]", value).get("children")  # noqa: TID251
+        if not isinstance(children, list):
             continue
-        for child_object in children_object:
-            if not isinstance(child_object, dict):
-                continue
-            _strip_archived_fields(data=child_object)
+        for child in cast("list[dict[str, object]]", children):  # noqa: TID251
+            _strip_archived_fields(data=child)
 
 
 def _block_serialize_for_api_patched(


### PR DESCRIPTION
## Summary
- Add literalizer DEPRECATED_BUILTINS.bad-functions pylint config.
- Ban typing.cast via ruff where applicable.
- Fix or pylint-disable existing violations.

## Test plan
- [ ] CI lint passes.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to lint configuration and adding targeted `noqa` suppressions for existing `typing.cast` usage, with no runtime behavior changes.
> 
> **Overview**
> Tightens static-analysis rules by **banning `typing.cast` via Ruff tidy-imports** (with a custom message) and adding a Pylint `DEPRECATED_BUILTINS.bad-functions` blocklist for dynamic builtins like `getattr`/`setattr`/`hasattr`/`map`/`filter`.
> 
> Adds `# noqa: TID251` suppressions in `sphinx_notion/_upload.py` where `cast(...)` is still used, to keep lint passing under the new rule.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 00243e7cf1b2f9cefe54ec15bb16008e4cc0d31c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->