### PR TITLE
Add --require-existing-page flag to notion-upload

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -368,6 +368,9 @@ Add the following configuration options to your ``conf.py``:
    # Optional: Cancel upload if blocks to be deleted have discussion threads
    notion_cancel_on_discussion = True
 
+   # Optional: Fail if no page with the given title exists
+   notion_require_existing_page = True
+
 **Configuration Options:**
 
 ``notion_publish``
@@ -405,6 +408,11 @@ Add the following configuration options to your ``conf.py``:
 ``notion_cancel_on_discussion``
    When set to ``True``, the upload will be cancelled with an error if any blocks that would be deleted have discussion threads attached to them.
    This helps prevent accidentally losing discussion content.
+   Default: ``False``
+
+``notion_require_existing_page``
+   When set to ``True``, the upload will fail with an error if no page with the given title exists, instead of creating a new page.
+   This helps catch silent forks when a page is renamed in Notion (or in configuration) and the uploader would otherwise create a new page alongside the old one.
    Default: ``False``
 
 Publishing the Sample Document Locally

--- a/newsfragments/+require-existing-page.change.rst
+++ b/newsfragments/+require-existing-page.change.rst
@@ -1,0 +1,1 @@
+Add a ``--require-existing-page`` flag to ``notion-upload`` which makes the upload fail if no page with the given title exists, instead of silently creating a new page.

--- a/src/_notion_scripts/upload.py
+++ b/src/_notion_scripts/upload.py
@@ -18,6 +18,7 @@ from sphinx_notion._upload import (
     DiscussionsExistError,
     PageHasDatabasesError,
     PageHasSubpagesError,
+    PageNotFoundError,
     upload_to_notion,
 )
 
@@ -86,6 +87,15 @@ from sphinx_notion._upload import (
     default=False,
 )
 @cloup.option(
+    "--require-existing-page",
+    help=(
+        "Fail if no page with the given title exists, instead of creating "
+        "a new page"
+    ),
+    is_flag=True,
+    default=False,
+)
+@cloup.option(
     "--notion-api-base-url",
     help=(
         "Override the Notion API base URL. "
@@ -104,6 +114,7 @@ def main(
     cover_path: Path | None,
     cover_url: str | None,
     cancel_on_discussion: bool,
+    require_existing_page: bool,
     notion_api_base_url: str | None,
 ) -> None:
     """Upload documentation to Notion."""
@@ -134,6 +145,7 @@ def main(
             cover_path=cover_path,
             cover_url=cover_url,
             cancel_on_discussion=cancel_on_discussion,
+            require_existing_page=require_existing_page,
         )
     except PageHasSubpagesError:
         error_message = (
@@ -148,6 +160,8 @@ def main(
         )
         raise click.ClickException(message=error_message) from None
     except DiscussionsExistError as exc:
+        raise click.ClickException(message=str(object=exc)) from None
+    except PageNotFoundError as exc:
         raise click.ClickException(message=str(object=exc)) from None
     finally:
         session.close()

--- a/src/sphinx_notion/__init__.py
+++ b/src/sphinx_notion/__init__.py
@@ -2411,6 +2411,7 @@ def _publish_to_notion(
             cover_path=None,
             cover_url=app.config.notion_page_cover_url,
             cancel_on_discussion=app.config.notion_cancel_on_discussion,
+            require_existing_page=app.config.notion_require_existing_page,
         )
     finally:
         session.close()
@@ -2466,6 +2467,12 @@ def setup(app: Sphinx) -> ExtensionMetadata:
     )
     app.add_config_value(
         name="notion_cancel_on_discussion",
+        default=False,
+        rebuild="",
+        types=(bool,),
+    )
+    app.add_config_value(
+        name="notion_require_existing_page",
         default=False,
         rebuild="",
         types=(bool,),

--- a/src/sphinx_notion/_upload.py
+++ b/src/sphinx_notion/_upload.py
@@ -107,6 +107,13 @@ class DiscussionsExistError(Exception):
     """
 
 
+class PageNotFoundError(Exception):
+    """Raised when no page with the given title exists and
+    require_existing_page
+    is True.
+    """
+
+
 class CloudflareWAFBlockError(Exception):
     """Raised when a request is blocked by the Cloudflare WAF before
     reaching Notion.
@@ -372,6 +379,7 @@ def upload_to_notion(  # noqa: C901, PLR0912, PLR0915
     cover_path: Path | None,
     cover_url: str | None,
     cancel_on_discussion: bool,
+    require_existing_page: bool,
 ) -> Page:
     """Upload documentation to Notion.
 
@@ -382,6 +390,8 @@ def upload_to_notion(  # noqa: C901, PLR0912, PLR0915
         PageHasDatabasesError: If the page has databases.
         DiscussionsExistError: If blocks to delete have discussions and
             cancel_on_discussion is True.
+        PageNotFoundError: If no page with the given title exists and
+            require_existing_page is True.
         CloudflareWAFBlockError: If the append request is blocked by the
             Cloudflare WAF before reaching Notion.
         HTTPResponseError: If the append request fails with a non-HTML
@@ -410,6 +420,9 @@ def upload_to_notion(  # noqa: C901, PLR0912, PLR0915
         assert len(pages_matching_title) == 1, msg
         (page,) = pages_matching_title
         _LOGGER.info("Found existing page '%s'", title)
+    elif require_existing_page:
+        msg = f"No page found with title '{title}'."
+        raise PageNotFoundError(msg)
     else:
         _LOGGER.info("Creating new page '%s'", title)
         page = session.create_page(parent=parent, title=title)

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -34,6 +34,7 @@ def _invoke_upload(
     parent_page_id: str,
     mock_api_base_url: str,
     cancel_on_discussion: bool = False,
+    require_existing_page: bool = False,
 ) -> Result:
     """Invoke the upload CLI against the mock Notion API."""
     runner = CliRunner()
@@ -49,6 +50,8 @@ def _invoke_upload(
     ]
     if cancel_on_discussion:
         arguments.append("--cancel-on-discussion")
+    if require_existing_page:
+        arguments.append("--require-existing-page")
     return runner.invoke(
         cli=main,
         args=arguments,
@@ -185,3 +188,32 @@ def test_upload_discussions_exist_error(
 
     assert result.exit_code == 1
     assert "discussion" in result.output.lower()
+
+
+def test_upload_page_not_found_error(
+    *,
+    mock_api_base_url: str,
+    notion_token: str,
+    parent_page_id: str,
+    tmp_path: Path,
+) -> None:
+    """A useful error is shown when the page does not exist and
+    --require-existing-page is given.
+    """
+    assert notion_token
+    blocks_file = _write_blocks_file(
+        tmp_path=tmp_path,
+        block_dicts=_paragraph_blocks(
+            text_content="Hello from WireMock upload test",
+        ),
+    )
+
+    result = _invoke_upload(
+        blocks_file=blocks_file,
+        parent_page_id=parent_page_id,
+        mock_api_base_url=mock_api_base_url,
+        require_existing_page=True,
+    )
+
+    assert result.exit_code == 1
+    assert "No page found with title 'Upload Title'." in result.output

--- a/tests/test_upload/test_help.txt
+++ b/tests/test_upload/test_help.txt
@@ -17,6 +17,8 @@ Other options:
   --icon TEXT                 Icon of the page
   --cancel-on-discussion      Cancel upload with error if blocks to be deleted
                               have discussion threads
+  --require-existing-page     Fail if no page with the given title exists,
+                              instead of creating a new page
   --notion-api-base-url TEXT  Override the Notion API base URL. Useful for tests
                               against a mock Notion API.
   --help                      Show this message and exit.

--- a/tests/test_upload_mock_api.py
+++ b/tests/test_upload_mock_api.py
@@ -27,6 +27,7 @@ from sphinx_notion._upload import (
     DiscussionsExistError,
     PageHasDatabasesError,
     PageHasSubpagesError,
+    PageNotFoundError,
 )
 from tests._wiremock import (
     count_mock_requests,
@@ -60,6 +61,7 @@ def test_upload_to_notion_with_wiremock(
         cover_path=None,
         cover_url=None,
         cancel_on_discussion=False,
+        require_existing_page=False,
     )
 
     assert page.title == "Upload Title"
@@ -99,6 +101,7 @@ def test_upload_deletes_and_replaces_changed_blocks(
         cover_path=None,
         cover_url=None,
         cancel_on_discussion=True,
+        require_existing_page=False,
     )
     after_delete_count = count_mock_requests(
         mock=respx_mock,
@@ -135,6 +138,7 @@ def test_upload_with_icon(
         cover_path=None,
         cover_url=None,
         cancel_on_discussion=False,
+        require_existing_page=False,
     )
 
     assert page.title == "Upload Title"
@@ -160,6 +164,7 @@ def test_upload_with_cover_url(
         cover_path=None,
         cover_url="https://example.com/cover.png",
         cancel_on_discussion=False,
+        require_existing_page=False,
     )
 
     assert page.title == "Upload Title"
@@ -183,6 +188,7 @@ def test_upload_page_has_subpages_error(
             cover_path=None,
             cover_url=None,
             cancel_on_discussion=False,
+            require_existing_page=False,
         )
 
 
@@ -201,6 +207,7 @@ def test_upload_page_has_databases_error(
             cover_path=None,
             cover_url=None,
             cancel_on_discussion=False,
+            require_existing_page=False,
         )
 
 
@@ -226,6 +233,37 @@ def test_upload_discussions_exist_error(
             cover_path=None,
             cover_url=None,
             cancel_on_discussion=True,
+            require_existing_page=False,
+        )
+
+
+def test_upload_page_not_found_error(
+    *,
+    notion_session: Session,
+    parent_page_id: str,
+) -> None:
+    """PageNotFoundError raised when no page matches the title and
+    require_existing_page is True.
+    """
+    with pytest.raises(
+        expected_exception=PageNotFoundError,
+        match=r"No page found with title 'Upload Title'\.",
+    ):
+        notion_upload.upload_to_notion(
+            session=notion_session,
+            blocks=[
+                UnoParagraph(
+                    text=text(text="Hello from WireMock upload test"),
+                ),
+            ],
+            parent_page_id=parent_page_id,
+            parent_database_id=None,
+            title="Upload Title",
+            icon=None,
+            cover_path=None,
+            cover_url=None,
+            cancel_on_discussion=False,
+            require_existing_page=True,
         )
 
 
@@ -256,6 +294,7 @@ def test_upload_with_database_parent(
         cover_path=None,
         cover_url=None,
         cancel_on_discussion=False,
+        require_existing_page=False,
     )
 
     after_count = count_mock_requests(
@@ -294,6 +333,7 @@ def test_upload_with_cover_path(
         cover_path=cover_file,
         cover_url=None,
         cancel_on_discussion=False,
+        require_existing_page=False,
     )
     after_upload_count = _file_upload_create_count(
         mock=respx_mock,
@@ -328,6 +368,7 @@ def test_upload_with_file_block(
         cover_path=None,
         cover_url=None,
         cancel_on_discussion=False,
+        require_existing_page=False,
     )
 
     assert page.title == "Upload Title"
@@ -372,6 +413,7 @@ def test_upload_with_nested_file_block(
         cover_path=None,
         cover_url=None,
         cancel_on_discussion=False,
+        require_existing_page=False,
     )
 
     assert page.title == "Upload Title"
@@ -421,6 +463,7 @@ def test_upload_prefix_suffix_matching(
         cover_path=None,
         cover_url=None,
         cancel_on_discussion=False,
+        require_existing_page=False,
     )
     after_delete_count = count_mock_requests(
         mock=respx_mock,
@@ -467,6 +510,7 @@ def test_upload_file_block_name_mismatch(
         cover_path=None,
         cover_url=None,
         cancel_on_discussion=False,
+        require_existing_page=False,
     )
     after_upload_count = _file_upload_create_count(
         mock=respx_mock,
@@ -503,6 +547,7 @@ def test_upload_file_block_caption_mismatch(
         cover_path=None,
         cover_url=None,
         cancel_on_discussion=False,
+        require_existing_page=False,
     )
     after_upload_count = _file_upload_create_count(
         mock=respx_mock,
@@ -536,6 +581,7 @@ def test_upload_file_block_external_url(
         cover_path=None,
         cover_url=None,
         cancel_on_discussion=False,
+        require_existing_page=False,
     )
     after_upload_count = _file_upload_create_count(
         mock=respx_mock,
@@ -569,6 +615,7 @@ def test_upload_file_block_existing_is_external(
         cover_path=None,
         cover_url=None,
         cancel_on_discussion=False,
+        require_existing_page=False,
     )
     after_upload_count = _file_upload_create_count(
         mock=respx_mock,
@@ -606,6 +653,7 @@ def test_upload_matching_parent_blocks(
         cover_path=None,
         cover_url=None,
         cancel_on_discussion=False,
+        require_existing_page=False,
     )
     after_delete_count = count_mock_requests(
         mock=respx_mock,
@@ -656,6 +704,7 @@ def test_upload_parent_block_different_children_count(
         cover_path=None,
         cover_url=None,
         cancel_on_discussion=False,
+        require_existing_page=False,
     )
     after_delete_count = count_mock_requests(
         mock=respx_mock,
@@ -722,6 +771,7 @@ def test_cloudflare_waf_block(
             cover_path=None,
             cover_url=None,
             cancel_on_discussion=False,
+            require_existing_page=False,
         )
 
 
@@ -755,6 +805,7 @@ def test_non_html_403_not_wrapped(
             cover_path=None,
             cover_url=None,
             cancel_on_discussion=False,
+            require_existing_page=False,
         )
 
 
@@ -784,4 +835,5 @@ def test_non_403_html_not_wrapped(
             cover_path=None,
             cover_url=None,
             cancel_on_discussion=False,
+            require_existing_page=False,
         )


### PR DESCRIPTION
## Summary

`notion-upload` matches the target page by title and silently creates a new page when no match is found.
If a page is renamed in Notion (or the configured title changes), the next upload forks a new page and the old page stops receiving updates, with no error to flag it.

This adds an opt-in way to fail loudly instead:

- New `--require-existing-page` CLI flag for `notion-upload`: when set and no page with the given title exists under the parent, the upload fails with `No page found with title '<title>'.` (exit code 1) instead of creating a new page.
- New `PageNotFoundError` raised by `upload_to_notion()` via a new `require_existing_page` keyword argument.
- Matching `notion_require_existing_page` Sphinx config value for the auto-publish path.

Default behavior is unchanged (pages are still created when the flag/config is not set).

## Testing

- New library test (`PageNotFoundError` raised against the mock API) and CLI test (exit code and error message).
- Regenerated the `--help` regression snapshot.
- `pytest --cov-fail-under 100 --cov=src/ --cov=tests/ .`: 209 passed, 100% coverage.
- `mypy`, `ty`, `ruff`, `pylint` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Default-off flag only changes behavior when enabled; upload logic otherwise unchanged aside from a new early error path.
> 
> **Overview**
> Adds an **opt-in** guard so Notion uploads do not silently create a new page when title lookup fails.
> 
> **`upload_to_notion`** gains `require_existing_page`; if no child page matches the title, it raises **`PageNotFoundError`** instead of calling `create_page`. **`notion-upload`** exposes **`--require-existing-page`**, maps the error to Click exit code 1, and Sphinx auto-publish reads **`notion_require_existing_page`** (default **False**, so behavior is unchanged unless enabled). README and a newsfragment document the option; CLI help snapshot, library, and CLI tests cover the failure path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d675418c75b0eeb96ea904149f6db24179a5e7bb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->