### PR TITLE
Add --page-id option to notion-upload

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -331,10 +331,14 @@ Arguments:
 - ``--parent-page-id``: The ID of the parent page in Notion (must be shared with your integration) - mutually exclusive with ``--parent-database-id``
 - ``--parent-database-id``: The ID of the parent database in Notion (must be shared with your integration) - mutually exclusive with ``--parent-page-id``
 - ``--title``: Title for the new page in Notion
+- ``--page-id``: (Optional) ID of an existing page to update; the page is renamed to the given title
 - ``--icon``: (Optional) Icon for the page (emoji)
 - ``--cover-path``: (Optional) Path to a cover image file for the page
 
 The command will create a new page if one with the given title doesn't exist, or update the existing page if one with the given title already exists.
+
+With ``--page-id``, the page is looked up by ID instead of by title, and the command fails if no page with that ID exists.
+This avoids a silent fork where renaming a page (in Notion or in your configuration) causes a new page to be created alongside the old one.
 
 Automatic Publishing Configuration
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -358,6 +362,9 @@ Add the following configuration options to your ``conf.py``:
 
    # Required: Title for the Notion page
    notion_page_title = "My Documentation"
+
+   # Optional: ID of an existing page to update (renamed to the title)
+   notion_page_id = "your-page-id-here"
 
    # Optional: Icon emoji for the page
    notion_page_icon = "📚"
@@ -392,6 +399,12 @@ Add the following configuration options to your ``conf.py``:
    This is required when ``notion_publish`` is ``True``.
    If a page with this title already exists under the parent, it will be updated.
    Otherwise, a new page will be created.
+   Default: ``None``
+
+``notion_page_id``
+   The ID of an existing Notion page to update.
+   When set, the page is looked up by ID instead of by title, and is renamed to ``notion_page_title``.
+   Publishing fails with an error if no page with this ID exists.
    Default: ``None``
 
 ``notion_page_icon``

--- a/newsfragments/+page-id.change.rst
+++ b/newsfragments/+page-id.change.rst
@@ -1,0 +1,1 @@
+Add a ``--page-id`` option to ``notion-upload`` (and a matching ``notion_page_id`` Sphinx configuration value) to update an existing page by ID instead of matching by title. The page is renamed to the given title, and the upload fails if no page with that ID exists, preventing a silent fork when a page is renamed.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -393,6 +393,7 @@ ignore_names = [
     "notion_cancel_on_discussion",
     "notion_page_cover_url",
     "notion_page_icon",
+    "notion_page_id",
     "notion_page_title",
     "notion_parent_database_id",
     "notion_parent_page_id",

--- a/src/_notion_scripts/upload.py
+++ b/src/_notion_scripts/upload.py
@@ -18,6 +18,7 @@ from sphinx_notion._upload import (
     DiscussionsExistError,
     PageHasDatabasesError,
     PageHasSubpagesError,
+    PageNotFoundError,
     upload_to_notion,
 )
 
@@ -50,6 +51,15 @@ from sphinx_notion._upload import (
     "--title",
     help="Title of the page to update (or create if it does not exist)",
     required=True,
+)
+@cloup.option(
+    "--page-id",
+    help=(
+        "ID of an existing page to update. The page is renamed to the "
+        "given title. Without this, the page is matched by title, and "
+        "created if no page with the title exists."
+    ),
+    required=False,
 )
 @cloup.option(
     "--icon",
@@ -100,6 +110,7 @@ def main(
     parent_page_id: str | None,
     parent_database_id: str | None,
     title: str,
+    page_id: str | None,
     icon: str | None,
     cover_path: Path | None,
     cover_url: str | None,
@@ -127,6 +138,7 @@ def main(
         page = upload_to_notion(
             session=session,
             blocks=blocks,
+            page_id=page_id,
             parent_page_id=parent_page_id,
             parent_database_id=parent_database_id,
             title=title,
@@ -148,6 +160,8 @@ def main(
         )
         raise click.ClickException(message=error_message) from None
     except DiscussionsExistError as exc:
+        raise click.ClickException(message=str(object=exc)) from None
+    except PageNotFoundError as exc:
         raise click.ClickException(message=str(object=exc)) from None
     finally:
         session.close()

--- a/src/sphinx_notion/__init__.py
+++ b/src/sphinx_notion/__init__.py
@@ -2404,6 +2404,7 @@ def _publish_to_notion(
         page = upload_to_notion(
             session=session,
             blocks=blocks,
+            page_id=app.config.notion_page_id,
             parent_page_id=app.config.notion_parent_page_id,
             parent_database_id=app.config.notion_parent_database_id,
             title=app.config.notion_page_title,
@@ -2469,6 +2470,12 @@ def setup(app: Sphinx) -> ExtensionMetadata:
         default=False,
         rebuild="",
         types=(bool,),
+    )
+    app.add_config_value(
+        name="notion_page_id",
+        default=None,
+        rebuild="",
+        types=(str,),
     )
     app.add_config_value(
         name="notion_api_base_url",

--- a/src/sphinx_notion/_upload.py
+++ b/src/sphinx_notion/_upload.py
@@ -23,6 +23,7 @@ from ultimate_notion.blocks import Block, ParentBlock
 from ultimate_notion.blocks import File as UnoFile
 from ultimate_notion.blocks import Image as UnoImage
 from ultimate_notion.blocks import Video as UnoVideo
+from ultimate_notion.errors import UnknownPageError
 from ultimate_notion.file import UploadedFile
 from ultimate_notion.obj_api.blocks import Block as UnoObjAPIBlock
 from ultimate_notion.page import Page
@@ -105,6 +106,10 @@ class DiscussionsExistError(Exception):
     cancel_on_discussion
     is True.
     """
+
+
+class PageNotFoundError(Exception):
+    """Raised when no page with the given ID exists."""
 
 
 class CloudflareWAFBlockError(Exception):
@@ -365,6 +370,7 @@ def upload_to_notion(  # noqa: C901, PLR0912, PLR0915
     *,
     session: Session,
     blocks: Sequence[Block],
+    page_id: str | None,
     parent_page_id: str | None,
     parent_database_id: str | None,
     title: str,
@@ -378,6 +384,8 @@ def upload_to_notion(  # noqa: C901, PLR0912, PLR0915
     Returns the page that was created or updated.
 
     Raises:
+        PageNotFoundError: If page_id is given and no page with that ID
+            exists or the page is not accessible.
         PageHasSubpagesError: If the page has subpages.
         PageHasDatabasesError: If the page has databases.
         DiscussionsExistError: If blocks to delete have discussions and
@@ -387,32 +395,46 @@ def upload_to_notion(  # noqa: C901, PLR0912, PLR0915
         HTTPResponseError: If the append request fails with a non-HTML
             error response.
     """
-    parent: Page | Database
-    if parent_page_id:
-        _LOGGER.info("Fetching parent page '%s'", parent_page_id)
-        parent = session.get_page(page_ref=parent_page_id)
-        subpages = parent.subpages
+    if page_id is not None:
+        _LOGGER.info("Fetching page '%s'", page_id)
+        try:
+            page = session.get_page(page_ref=page_id)
+        except UnknownPageError as exc:
+            msg = (
+                f"No page found with ID '{page_id}'. "
+                "It may not exist, or it may not be shared with the "
+                "integration."
+            )
+            raise PageNotFoundError(msg) from exc
+        _LOGGER.info("Setting page title to '%s'", title)
+        page.title = title
     else:
-        assert parent_database_id is not None
-        _LOGGER.info("Fetching parent database '%s'", parent_database_id)
-        parent = session.get_db(db_ref=parent_database_id)
-        subpages = parent.get_all_pages().to_pages()
+        parent: Page | Database
+        if parent_page_id:
+            _LOGGER.info("Fetching parent page '%s'", parent_page_id)
+            parent = session.get_page(page_ref=parent_page_id)
+            subpages = parent.subpages
+        else:
+            assert parent_database_id is not None
+            _LOGGER.info("Fetching parent database '%s'", parent_database_id)
+            parent = session.get_db(db_ref=parent_database_id)
+            subpages = parent.get_all_pages().to_pages()
 
-    pages_matching_title = [
-        child_page for child_page in subpages if child_page.title == title
-    ]
+        pages_matching_title = [
+            child_page for child_page in subpages if child_page.title == title
+        ]
 
-    if pages_matching_title:
-        msg = (
-            f"Expected 1 page matching title {title}, but got "
-            f"{len(pages_matching_title)}"
-        )
-        assert len(pages_matching_title) == 1, msg
-        (page,) = pages_matching_title
-        _LOGGER.info("Found existing page '%s'", title)
-    else:
-        _LOGGER.info("Creating new page '%s'", title)
-        page = session.create_page(parent=parent, title=title)
+        if pages_matching_title:
+            msg = (
+                f"Expected 1 page matching title {title}, but got "
+                f"{len(pages_matching_title)}"
+            )
+            assert len(pages_matching_title) == 1, msg
+            (page,) = pages_matching_title
+            _LOGGER.info("Found existing page '%s'", title)
+        else:
+            _LOGGER.info("Creating new page '%s'", title)
+            page = session.create_page(parent=parent, title=title)
 
     if icon:
         _LOGGER.info("Setting page icon to '%s'", icon)

--- a/tests/notion_sandbox/notion-wiremock-stubs.json
+++ b/tests/notion_sandbox/notion-wiremock-stubs.json
@@ -165,6 +165,25 @@
       "persistent": true
     },
     {
+      "name": "retrieveMissingPage",
+      "request": {
+        "method": "GET",
+        "urlPath": "/v1/pages/40400000-0000-0000-0000-000000000404"
+      },
+      "response": {
+        "status": 404,
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "jsonBody": {
+          "object": "error",
+          "status": 404,
+          "code": "object_not_found",
+          "message": "Could not find page with ID: 40400000-0000-0000-0000-000000000404."
+        }
+      }
+    },
+    {
       "name": "updatePage",
       "request": {
         "method": "PATCH",

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -1,9 +1,11 @@
 """Tests for the upload script."""
 
 import json
+import logging
 from pathlib import Path
 from typing import Any
 
+import pytest
 from click.testing import CliRunner, Result
 from pytest_regressions.file_regression import FileRegressionFixture
 from ultimate_notion.blocks import (
@@ -34,6 +36,7 @@ def _invoke_upload(
     parent_page_id: str,
     mock_api_base_url: str,
     cancel_on_discussion: bool = False,
+    page_id: str | None = None,
 ) -> Result:
     """Invoke the upload CLI against the mock Notion API."""
     runner = CliRunner()
@@ -49,6 +52,8 @@ def _invoke_upload(
     ]
     if cancel_on_discussion:
         arguments.append("--cancel-on-discussion")
+    if page_id is not None:
+        arguments.extend(["--page-id", page_id])
     return runner.invoke(
         cli=main,
         args=arguments,
@@ -185,3 +190,71 @@ def test_upload_discussions_exist_error(
 
     assert result.exit_code == 1
     assert "discussion" in result.output.lower()
+
+
+def test_upload_with_page_id(
+    *,
+    mock_api_base_url: str,
+    notion_token: str,
+    parent_page_id: str,
+    tmp_path: Path,
+) -> None:
+    """Uploading to a page given by ID reports success."""
+    assert notion_token
+    blocks_file = _write_blocks_file(
+        tmp_path=tmp_path,
+        block_dicts=_paragraph_blocks(
+            text_content="Hello from WireMock upload test",
+        ),
+    )
+
+    result = _invoke_upload(
+        blocks_file=blocks_file,
+        parent_page_id=parent_page_id,
+        mock_api_base_url=mock_api_base_url,
+        page_id=parent_page_id,
+    )
+
+    assert result.exit_code == 0, (result.stdout, result.stderr)
+    assert result.output == (
+        "Uploaded page: 'Upload Title' "
+        "(https://www.notion.so/Upload-Title-59833787)\n"
+    )
+
+
+def test_upload_page_not_found_error(
+    *,
+    caplog: pytest.LogCaptureFixture,
+    mock_api_base_url: str,
+    notion_token: str,
+    parent_page_id: str,
+    tmp_path: Path,
+) -> None:
+    """A useful error is shown when no page with the given ID exists."""
+    # The missing page triggers a WARNING log from ``ultimate_notion``.
+    # With ``log_cli`` enabled, the live-log handler in ``pytest``
+    # suspends and resumes global capture for WARNING records, which
+    # replaces ``sys.stderr`` mid-invocation and breaks the stream
+    # capture of ``CliRunner``.  Silence the logger so
+    # ``result.output`` stays intact.
+    caplog.set_level(level=logging.ERROR, logger="ultimate_notion.session")
+    assert notion_token
+    blocks_file = _write_blocks_file(
+        tmp_path=tmp_path,
+        block_dicts=_paragraph_blocks(
+            text_content="Hello from WireMock upload test",
+        ),
+    )
+
+    result = _invoke_upload(
+        blocks_file=blocks_file,
+        parent_page_id=parent_page_id,
+        mock_api_base_url=mock_api_base_url,
+        page_id="40400000-0000-0000-0000-000000000404",
+    )
+
+    assert result.exit_code == 1
+    assert (
+        "No page found with ID '40400000-0000-0000-0000-000000000404'."
+        in result.output
+    )

--- a/tests/test_upload/test_help.txt
+++ b/tests/test_upload/test_help.txt
@@ -14,6 +14,10 @@ Other options:
   --file FILE                 JSON File to upload  [required]
   --title TEXT                Title of the page to update (or create if it does
                               not exist)  [required]
+  --page-id TEXT              ID of an existing page to update. The page is
+                              renamed to the given title. Without this, the page
+                              is matched by title, and created if no page with
+                              the title exists.
   --icon TEXT                 Icon of the page
   --cancel-on-discussion      Cancel upload with error if blocks to be deleted
                               have discussion threads

--- a/tests/test_upload_mock_api.py
+++ b/tests/test_upload_mock_api.py
@@ -27,6 +27,7 @@ from sphinx_notion._upload import (
     DiscussionsExistError,
     PageHasDatabasesError,
     PageHasSubpagesError,
+    PageNotFoundError,
 )
 from tests._wiremock import (
     count_mock_requests,
@@ -53,6 +54,7 @@ def test_upload_to_notion_with_wiremock(
         blocks=[
             UnoParagraph(text=text(text="Hello from WireMock upload test"))
         ],
+        page_id=None,
         parent_page_id=parent_page_id,
         parent_database_id=None,
         title="Upload Title",
@@ -92,6 +94,7 @@ def test_upload_deletes_and_replaces_changed_blocks(
         blocks=[
             UnoParagraph(text=text(text="Different content triggers sync"))
         ],
+        page_id=None,
         parent_page_id=parent_page_id,
         parent_database_id=None,
         title="Upload Title",
@@ -128,6 +131,7 @@ def test_upload_with_icon(
         blocks=[
             UnoParagraph(text=text(text="Hello from WireMock upload test"))
         ],
+        page_id=None,
         parent_page_id=parent_page_id,
         parent_database_id=None,
         title="Upload Title",
@@ -153,6 +157,7 @@ def test_upload_with_cover_url(
         blocks=[
             UnoParagraph(text=text(text="Hello from WireMock upload test"))
         ],
+        page_id=None,
         parent_page_id=parent_page_id,
         parent_database_id=None,
         title="Upload Title",
@@ -176,6 +181,7 @@ def test_upload_page_has_subpages_error(
         notion_upload.upload_to_notion(
             session=notion_session,
             blocks=[],
+            page_id=None,
             parent_page_id="aaaa0000-0000-0000-0000-000000000001",
             parent_database_id=None,
             title="Upload Title",
@@ -194,6 +200,7 @@ def test_upload_page_has_databases_error(
         notion_upload.upload_to_notion(
             session=notion_session,
             blocks=[],
+            page_id=None,
             parent_page_id="bbbb0000-0000-0000-0000-000000000001",
             parent_database_id=None,
             title="Upload Title",
@@ -219,6 +226,7 @@ def test_upload_discussions_exist_error(
                     text=text(text="Different content triggers sync"),
                 ),
             ],
+            page_id=None,
             parent_page_id="cccc0000-0000-0000-0000-000000000001",
             parent_database_id=None,
             title="Upload Title",
@@ -226,6 +234,62 @@ def test_upload_discussions_exist_error(
             cover_path=None,
             cover_url=None,
             cancel_on_discussion=True,
+        )
+
+
+def test_upload_with_page_id(
+    *,
+    notion_session: Session,
+    parent_page_id: str,
+) -> None:
+    """A page given by ID is updated and renamed to the given title."""
+    page = notion_upload.upload_to_notion(
+        session=notion_session,
+        blocks=[
+            UnoParagraph(text=text(text="Hello from WireMock upload test"))
+        ],
+        page_id=parent_page_id,
+        parent_page_id=None,
+        parent_database_id=None,
+        title="Upload Title",
+        icon=None,
+        cover_path=None,
+        cover_url=None,
+        cancel_on_discussion=False,
+    )
+
+    assert page.title == "Upload Title"
+    assert str(object=page.id) == parent_page_id
+    assert len(page.blocks) == 1
+    assert isinstance(page.blocks[0], UnoParagraph)
+    assert page.blocks[0].rich_text == "Hello from WireMock upload test"
+
+
+def test_upload_page_not_found_error(
+    *,
+    notion_session: Session,
+) -> None:
+    """PageNotFoundError raised when no page with the given ID exists."""
+    missing_page_id = "40400000-0000-0000-0000-000000000404"
+    with pytest.raises(
+        expected_exception=PageNotFoundError,
+        match=f"No page found with ID '{missing_page_id}'.",
+    ):
+        notion_upload.upload_to_notion(
+            session=notion_session,
+            blocks=[
+                UnoParagraph(
+                    text=text(text="Hello from WireMock upload test"),
+                ),
+            ],
+            page_id=missing_page_id,
+            parent_page_id=None,
+            parent_database_id=None,
+            title="Upload Title",
+            icon=None,
+            cover_path=None,
+            cover_url=None,
+            cancel_on_discussion=False,
         )
 
 
@@ -249,6 +313,7 @@ def test_upload_with_database_parent(
         blocks=[
             UnoParagraph(text=text(text="Hello from Microcks upload test"))
         ],
+        page_id=None,
         parent_page_id=None,
         parent_database_id=parent_database_id,
         title="Upload Title",
@@ -287,6 +352,7 @@ def test_upload_with_cover_path(
         blocks=[
             UnoParagraph(text=text(text="Hello from Microcks upload test"))
         ],
+        page_id=None,
         parent_page_id=parent_page_id,
         parent_database_id=None,
         title="Upload Title",
@@ -321,6 +387,7 @@ def test_upload_with_file_block(
         blocks=[
             UnoImage(file=ExternalFile(url=img_file.as_uri())),
         ],
+        page_id=None,
         parent_page_id=parent_page_id,
         parent_database_id=None,
         title="Upload Title",
@@ -365,6 +432,7 @@ def test_upload_with_nested_file_block(
     page = notion_upload.upload_to_notion(
         session=notion_session,
         blocks=[parent_block],
+        page_id=None,
         parent_page_id=parent_page_id,
         parent_database_id=None,
         title="Upload Title",
@@ -414,6 +482,7 @@ def test_upload_prefix_suffix_matching(
             UnoParagraph(text=text(text="new")),
             Divider(),
         ],
+        page_id=None,
         parent_page_id="dddd0000-0000-0000-0000-000000000001",
         parent_database_id=None,
         title="Upload Title",
@@ -460,6 +529,7 @@ def test_upload_file_block_name_mismatch(
                 ),
             ),
         ],
+        page_id=None,
         parent_page_id="eeee0000-0000-0000-0000-000000000001",
         parent_database_id=None,
         title="Upload Title",
@@ -496,6 +566,7 @@ def test_upload_file_block_caption_mismatch(
                 caption="new caption",
             ),
         ],
+        page_id=None,
         parent_page_id="eeee0000-0000-0000-0000-000000000001",
         parent_database_id=None,
         title="Upload Title",
@@ -529,6 +600,7 @@ def test_upload_file_block_external_url(
                 ),
             ),
         ],
+        page_id=None,
         parent_page_id="eeee0000-0000-0000-0000-000000000001",
         parent_database_id=None,
         title="Upload Title",
@@ -562,6 +634,7 @@ def test_upload_file_block_existing_is_external(
         blocks=[
             UnoImage(file=ExternalFile(url=img_file.as_uri())),
         ],
+        page_id=None,
         parent_page_id="ffff0000-0000-0000-0000-000000000001",
         parent_database_id=None,
         title="Upload Title",
@@ -599,6 +672,7 @@ def test_upload_matching_parent_blocks(
     notion_upload.upload_to_notion(
         session=notion_session,
         blocks=[local_block],
+        page_id=None,
         parent_page_id="aabb0000-0000-0000-0000-000000000001",
         parent_database_id=None,
         title="Upload Title",
@@ -649,6 +723,7 @@ def test_upload_parent_block_different_children_count(
     notion_upload.upload_to_notion(
         session=notion_session,
         blocks=[local_block],
+        page_id=None,
         parent_page_id="aabb0000-0000-0000-0000-000000000001",
         parent_database_id=None,
         title="Upload Title",
@@ -715,6 +790,7 @@ def test_cloudflare_waf_block(
         notion_upload.upload_to_notion(
             session=notion_session,
             blocks=[UnoParagraph(text=text(text="WAF trigger content"))],
+            page_id=None,
             parent_page_id=parent_page_id,
             parent_database_id=None,
             title="Upload Title",
@@ -748,6 +824,7 @@ def test_non_html_403_not_wrapped(
         notion_upload.upload_to_notion(
             session=notion_session,
             blocks=[UnoParagraph(text=text(text="Content"))],
+            page_id=None,
             parent_page_id=parent_page_id,
             parent_database_id=None,
             title="Upload Title",
@@ -777,6 +854,7 @@ def test_non_403_html_not_wrapped(
         notion_upload.upload_to_notion(
             session=notion_session,
             blocks=[UnoParagraph(text=text(text="Content"))],
+            page_id=None,
             parent_page_id=parent_page_id,
             parent_database_id=None,
             title="Upload Title",


### PR DESCRIPTION
## Summary

`notion-upload` matches the target page by title and silently creates a new page when no match is found.
If a page is renamed in Notion (or the configured title changes), the next upload forks a new page and the old page stops receiving updates, with no error to flag it.

This makes it possible to pin the target page by ID instead:

- New `--page-id` option for `notion-upload`: the page is looked up by ID and renamed to `--title`, so the title becomes a property the uploader sets rather than the way the page is identified. Title changes (in either direction) can no longer fork the page.
- New `PageNotFoundError` raised by `upload_to_notion()` when the ID does not exist or is not shared with the integration — surfaced by the CLI as a clean error (exit code 1).
- Matching `notion_page_id` Sphinx config value for the auto-publish path.

Without `--page-id`, behavior is unchanged (match by title, create if missing), which remains the way to bootstrap a brand-new page.

## Testing

- New mock-API stub for a 404 page retrieval, plus library tests (update-by-ID happy path, `PageNotFoundError`) and CLI tests (success output, error message and exit code).
- One test silences a WARNING log from `ultimate_notion`: with `log_cli` enabled, the pytest live-log handler suspends/resumes global capture for WARNING records mid-invocation, which breaks `CliRunner`'s stream capture (comment in the test explains this).
- Regenerated the `--help` regression snapshot.
- `pytest --cov-fail-under 100 --cov=src/ --cov=tests/ .`: 211 passed, 100% coverage.
- `mypy`, `ty`, `ruff` (check + format), `pylint` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how the upload target is resolved when ID pinning is used; wrong ID fails loudly, but title renames on the pinned page are intentional.
> 
> **Overview**
> Adds **`--page-id`** to `notion-upload` and **`notion_page_id`** for Sphinx auto-publish so uploads can target a **fixed Notion page by ID** instead of matching on title.
> 
> When `page_id` is set, `upload_to_notion` loads that page, **renames it to the configured title**, then syncs blocks as before. Missing or inaccessible IDs raise **`PageNotFoundError`** (CLI exit 1). Without `page_id`, behavior is unchanged: find or create under the parent by title.
> 
> Docs, newsfragment, WireMock 404 stub, and tests cover the happy path and not-found errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3384935a267a9a5718dff53ba9b210d3531fb992. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->