### PR TITLE
chore(deps-dev): Bump wiremock-mock from 2026.3.2.1 to 2026.6.22

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,7 +98,7 @@ optional-dependencies.dev = [
     "types-docutils==0.22.3.20260518",
     "types-requests==2.33.0.20260518",
     "vulture==2.16",
-    "wiremock-mock==2026.3.2.1",
+    "wiremock-mock==2026.6.22",
     "yamlfix==1.19.1",
     "zizmor==1.26.1",
 ]

--- a/src/sphinx_notion/__init__.py
+++ b/src/sphinx_notion/__init__.py
@@ -185,7 +185,9 @@ def _serialize_block_with_children(
     """
     serialized_obj = block.obj_ref.serialize_for_api()
     if isinstance(block, ParentBlock) and block.has_children:
-        serialized_obj[block.obj_ref.type]["children"] = [
+        block_type = block.obj_ref.type
+        assert block_type is not None
+        serialized_obj[block_type]["children"] = [
             _serialize_block_with_children(block=child)
             for child in block.blocks
         ]

--- a/src/sphinx_notion/_upload.py
+++ b/src/sphinx_notion/_upload.py
@@ -66,7 +66,7 @@ def _block_serialize_for_api_patched(
     return data
 
 
-UnoObjAPIBlock.serialize_for_api = _block_serialize_for_api_patched  # type: ignore[assignment]  # ty: ignore[invalid-assignment]
+UnoObjAPIBlock.serialize_for_api = _block_serialize_for_api_patched  # type: ignore[method-assign]  # ty: ignore[invalid-assignment]
 
 _FILE_BLOCK_TYPES = (UnoImage, UnoVideo, UnoAudio, UnoPDF, UnoFile)
 _HTTP_FORBIDDEN = 403

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -73,7 +73,9 @@ def _details_from_block(*, block: Block) -> dict[str, Any]:
     """Create a serialized block details from a Block."""
     serialized_obj = block.obj_ref.serialize_for_api()
     if isinstance(block, ParentBlock) and block.has_children:
-        serialized_obj[block.obj_ref.type]["children"] = [
+        block_type = block.obj_ref.type
+        assert block_type is not None
+        serialized_obj[block_type]["children"] = [
             _details_from_block(block=child) for child in block.blocks
         ]
     return serialized_obj


### PR DESCRIPTION
Bumps the dev dependency `wiremock-mock` from `2026.3.2.1` to the latest release `2026.6.22` in `pyproject.toml`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dev-only dependency bump plus assert-based type narrowing and a comment-only type-ignore tweak; no runtime behavior change in production code paths.
> 
> **Overview**
> Bumps the dev dependency **`wiremock-mock`** from `2026.3.2.1` to `2026.6.22` in `pyproject.toml`.
> 
> The upgrade is paired with small typing fixes so block serialization stays valid under stricter checks: **`_serialize_block_with_children`** (and the matching test helper **`_details_from_block`**) now assign `block.obj_ref.type` to a local variable and **`assert block_type is not None`** before using it as the key when attaching nested `children`. **`_upload.py`** updates the monkey-patch **`type: ignore`** from `assignment` to **`method-assign`** on `UnoObjAPIBlock.serialize_for_api`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ac54f6ce9d667247c9695b0d514fdd41976c488. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->