### PR TITLE
chore(deps-dev): Bump wiremock-mock from 2026.3.2.1 to 2026.6.22

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,7 +98,7 @@ optional-dependencies.dev = [
     "types-docutils==0.22.3.20260518",
     "types-requests==2.33.0.20260518",
     "vulture==2.16",
-    "wiremock-mock==2026.3.2.1",
+    "wiremock-mock==2026.6.22",
     "yamlfix==1.19.1",
     "zizmor==1.26.1",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,10 +39,6 @@ dependencies = [
     "cloup>=3.0.0",
     "docutils>=0.21",
     "notion-client>=2.3.0",
-    # Pin pydantic to <2.13 to work around
-    # https://github.com/ultimate-notion/ultimate-notion/issues/189 -
-    # pydantic 2.13 breaks ultimate-notion's parsing of Notion user objects.
-    "pydantic<2.13",
     "requests>=2.32.5",
     "sphinx>=9,<10",
     "sphinx-iframes>=1.1.0",
@@ -339,9 +335,6 @@ ignore = [
 ]
 
 [tool.deptry]
-# pydantic is pinned to work around an ultimate-notion incompatibility,
-# not imported directly.
-per_rule_ignores = { DEP002 = [ "pydantic" ] }
 optional_dependencies_dev_groups = [
     "dev",
     "release",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ dependencies = [
     "sphinxcontrib-mermaid>=1.0.0",
     "sphinxcontrib-video>=0.4.0",
     "sphinxnotes-strike>=2.0",
-    "ultimate-notion>=0.9.6",
+    "ultimate-notion>=0.9.8",
 ]
 optional-dependencies.dev = [
     "actionlint-py==1.7.12.24",

--- a/src/sphinx_notion/__init__.py
+++ b/src/sphinx_notion/__init__.py
@@ -185,7 +185,9 @@ def _serialize_block_with_children(
     """
     serialized_obj = block.obj_ref.serialize_for_api()
     if isinstance(block, ParentBlock) and block.has_children:
-        serialized_obj[block.obj_ref.type]["children"] = [
+        block_type = block.obj_ref.type
+        assert block_type is not None
+        serialized_obj[block_type]["children"] = [
             _serialize_block_with_children(block=child)
             for child in block.blocks
         ]

--- a/src/sphinx_notion/_upload.py
+++ b/src/sphinx_notion/_upload.py
@@ -66,7 +66,7 @@ def _block_serialize_for_api_patched(
     return data
 
 
-UnoObjAPIBlock.serialize_for_api = _block_serialize_for_api_patched  # type: ignore[assignment]  # ty: ignore[invalid-assignment]
+UnoObjAPIBlock.serialize_for_api = _block_serialize_for_api_patched  # type: ignore[method-assign]  # ty: ignore[invalid-assignment]
 
 _FILE_BLOCK_TYPES = (UnoImage, UnoVideo, UnoAudio, UnoPDF, UnoFile)
 _HTTP_FORBIDDEN = 403

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -73,7 +73,9 @@ def _details_from_block(*, block: Block) -> dict[str, Any]:
     """Create a serialized block details from a Block."""
     serialized_obj = block.obj_ref.serialize_for_api()
     if isinstance(block, ParentBlock) and block.has_children:
-        serialized_obj[block.obj_ref.type]["children"] = [
+        block_type = block.obj_ref.type
+        assert block_type is not None
+        serialized_obj[block_type]["children"] = [
             _details_from_block(block=child) for child in block.blocks
         ]
     return serialized_obj


### PR DESCRIPTION
Bumps the `wiremock-mock` dev dependency from 2026.3.2.1 to 2026.6.22.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly dependency and typing/assertion tweaks in serialization helpers; runtime behavior should match once block types are set.
> 
> **Overview**
> **Dependency updates:** Bumps **`ultimate-notion`** to `>=0.9.8` and removes the **`pydantic<2.13`** pin and related comments/workarounds (issue #189). Dev **`wiremock-mock`** goes from `2026.3.2.1` to `2026.6.22`. **deptry** no longer ignores `pydantic` under DEP002.
> 
> **Typing for block serialization:** In `_serialize_block_with_children` (and the integration test helper `_details_from_block`), nested children are keyed using a local `block_type` with `assert block_type is not None` instead of indexing `serialized_obj` with `block.obj_ref.type` directly—likely for stricter typing with the newer **ultimate-notion**.
> 
> **Minor:** `_upload.py` updates the mypy ignore on the `serialize_for_api` monkey-patch to `method-assign`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d39dce773cdb2d69dfd3da426260f2d41af16d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->