### PR TITLE
Strip archived/has_children from nested blocks on Notion upload

### DIFF
--- a/newsfragments/+strip-nested-archived.change.rst
+++ b/newsfragments/+strip-nested-archived.change.rst
@@ -1,0 +1,1 @@
+Strip ``is_archived`` and ``has_children`` from nested blocks when uploading to Notion. Previously these fields were only removed from top-level blocks, so deeply nested blocks (such as admonitions nested inside admonitions) caused the Notion API to reject the upload with a validation error.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -170,6 +170,11 @@ lint.per-file-ignores."tests/*.py" = [
 lint.unfixable = [
     "ERA001",
 ]
+# ``KW001`` is emitted by ``strict-kwargs``, not Ruff. Registering it as an
+# external code lets us use ``# noqa: KW001`` without Ruff reporting RUF102.
+lint.external = [
+    "KW001",
+]
 lint.flake8-tidy-imports.banned-api."typing.cast".msg = "typing.cast is banned: use explicit type narrowing or a typed variable instead."
 lint.pydocstyle.convention = "google"
 

--- a/spelling_private_dict.txt
+++ b/spelling_private_dict.txt
@@ -14,6 +14,7 @@ desc
 hardcode
 hardcodes
 href
+noqa
 pragma
 preprocess
 pyrefly

--- a/src/sphinx_notion/_upload.py
+++ b/src/sphinx_notion/_upload.py
@@ -42,11 +42,13 @@ _original_serialize_for_api_method: Callable[
 
 
 def _strip_archived_fields(*, data: dict[str, object]) -> None:
-    """Recursively remove archived/in_trash from a serialized block
-    dict.
+    """Recursively remove archived/in_trash/is_archived/has_children from
+    a serialized block dict.
     """
     data.pop("archived", None)
     data.pop("in_trash", None)
+    data.pop("is_archived", None)
+    data.pop("has_children", None)
     for value in data.values():
         if not isinstance(value, dict):
             continue
@@ -81,7 +83,7 @@ def _file_uri_to_path(*, uri: str) -> Path:  # pragma: no cover
         url2pathname,  # ty: ignore[deprecated]
     )
 
-    return Path(url2pathname(urlparse(uri).path))  # ty: ignore[deprecated]
+    return Path(url2pathname(urlparse(uri).path))  # ty: ignore[deprecated]  # noqa: KW001
 
 
 @beartype

--- a/tests/test_upload_mock_api.py
+++ b/tests/test_upload_mock_api.py
@@ -1,5 +1,6 @@
 """Integration test for upload synchronization against a mock API."""
 
+import json
 import re
 from pathlib import Path
 from unittest.mock import patch
@@ -10,7 +11,9 @@ import respx
 from notion_client.errors import HTTPResponseError
 from ultimate_notion import ExternalFile, Session
 from ultimate_notion.blocks import (
+    Block,
     BulletedItem,
+    Callout,
     ChildrenMixin,
     Divider,
 )
@@ -18,6 +21,7 @@ from ultimate_notion.blocks import Image as UnoImage
 from ultimate_notion.blocks import (
     Paragraph as UnoParagraph,
 )
+from ultimate_notion.obj_api.blocks import Block as UnoObjAPIBlock
 from ultimate_notion.obj_api.objects import UploadedFile as UnoUploadedFile
 from ultimate_notion.rich_text import text
 
@@ -863,3 +867,32 @@ def test_non_403_html_not_wrapped(
             cover_url=None,
             cancel_on_discussion=False,
         )
+
+
+def _nested_callout_dict(*, depth: int) -> dict[str, object]:
+    """A callout dict nested ``depth`` levels deep, as produced by the
+    builder.
+    """
+    callout = Callout(text=text(text=f"Level {depth}"))
+    serialized = callout.obj_ref.serialize_for_api()
+    if depth > 1:
+        child = _nested_callout_dict(depth=depth - 1)
+        callout_body = serialized["callout"]
+        assert isinstance(callout_body, dict)
+        callout_body["children"] = [child]
+    return serialized
+
+
+def test_deeply_nested_blocks_strip_rejected_fields() -> None:
+    """Serializing deeply nested blocks strips fields the Notion API
+    rejects at every level of nesting.
+
+    Regression test: each nested callout block retained ``is_archived``
+    and ``has_children``, which the API rejects on append.
+    """
+    block_dict = _nested_callout_dict(depth=3)
+    block = Block.wrap_obj_ref(UnoObjAPIBlock.model_validate(obj=block_dict))
+    serialized = block.obj_ref.serialize_for_api()
+    serialized_text = json.dumps(obj=serialized)
+    for field in ("archived", "in_trash", "is_archived", "has_children"):
+        assert f'"{field}"' not in serialized_text


### PR DESCRIPTION
The "Publish documentation to Notion" workflow on `main` was failing because the Notion API now rejects `is_archived` and `has_children` fields on nested blocks during append, breaking uploads of deeply-nested admonitions (callout-in-callout-in-callout) in the sample docs. The uploader's recursive field-stripping only removed `archived` and `in_trash`, so nested blocks kept the other two fields. This strips `is_archived` and `has_children` recursively too, matching the top-level behaviour, and adds a regression test plus a news fragment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted serialization sanitizer for upload payloads with a focused regression test; no auth or data-model changes.
> 
> **Overview**
> Fixes Notion publish failures when docs contain **deeply nested admonitions/callouts**: the uploader already stripped `archived` and `in_trash` recursively, but nested serialized blocks could still carry **`is_archived`** and **`has_children`**, which the append API rejects.
> 
> **`_strip_archived_fields`** in `_upload.py` now removes those two keys at every nesting level (same monkey-patched `serialize_for_api` path). A **regression test** builds three-level nested callouts and asserts none of the rejected fields appear in the serialized JSON.
> 
> Tooling-only tweaks: register Ruff **`lint.external`** for `KW001` (strict-kwargs `noqa`), add **`noqa`** on the legacy `url2pathname` line, plus a **towncrier** news fragment.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d19fbc4a0b50e179894390645e26d8d3f08427a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->