### PR TITLE
Append new blocks before deleting old ones on Notion upload

### DIFF
--- a/newsfragments/+append-before-delete.change.rst
+++ b/newsfragments/+append-before-delete.change.rst
@@ -1,0 +1,1 @@
+Append new blocks before deleting the replaced ones when syncing a Notion page. The delete and append are separate, non-atomic API calls, so a failed or interrupted upload no longer erases the page: it is left with duplicated content that self-heals on the next successful sync, rather than with the old content gone and the new content never written.

--- a/src/sphinx_notion/_upload.py
+++ b/src/sphinx_notion/_upload.py
@@ -505,22 +505,26 @@ def upload_to_notion(  # noqa: C901, PLR0912, PLR0915
         )
         raise DiscussionsExistError(error_message)
 
-    for block_index, existing_page_block in enumerate(
-        iterable=blocks_to_delete
-    ):
-        _LOGGER.info(
-            "Deleting block %d/%d",
-            block_index + 1,
-            len(blocks_to_delete),
-        )
-        existing_page_block.delete()
-
     _LOGGER.info("Preparing %d blocks for upload", len(blocks_to_upload))
     block_objs_with_uploaded_files = [
         _block_with_uploaded_file(block=block, session=session)
         for block in blocks_to_upload
     ]
 
+    # Append the new blocks *before* deleting the old ones.
+    #
+    # The append and the deletions are separate, non-atomic Notion API
+    # calls. If we deleted first and a later append failed (rate limiting,
+    # a Cloudflare WAF block, a timeout) or the process was interrupted in
+    # between, the page would be left with the old content gone and the new
+    # content never written: an erased page and irrecoverable data loss.
+    #
+    # By appending first, a failure or interruption leaves the page with
+    # both the new and the old blocks (duplicated content), which is
+    # harmless and self-heals on the next successful sync. The new blocks
+    # are inserted directly after the matching prefix and before the blocks
+    # being replaced, so a fully successful sync still produces the same
+    # final ordering.
     if block_objs_with_uploaded_files:
         _LOGGER.info(
             "Appending %d blocks to page",
@@ -540,4 +544,15 @@ def upload_to_notion(  # noqa: C901, PLR0912, PLR0915
             ).startswith("text/html"):
                 raise
             raise CloudflareWAFBlockError from exc
+
+    for block_index, existing_page_block in enumerate(
+        iterable=blocks_to_delete
+    ):
+        _LOGGER.info(
+            "Deleting block %d/%d",
+            block_index + 1,
+            len(blocks_to_delete),
+        )
+        existing_page_block.delete()
+
     return page

--- a/tests/notion_sandbox/notion-wiremock-stubs.json
+++ b/tests/notion_sandbox/notion-wiremock-stubs.json
@@ -2852,6 +2852,40 @@
             },
             {
               "object": "block",
+              "id": "dddd0000-0000-0000-0000-000000000011",
+              "parent": {
+                "type": "page_id",
+                "page_id": "dddd0000-0000-0000-0000-000000000002"
+              },
+              "created_time": "2023-02-24T21:06:00.000Z",
+              "last_edited_time": "2023-02-24T21:06:00.000Z",
+              "has_children": false,
+              "archived": false,
+              "in_trash": false,
+              "type": "paragraph",
+              "paragraph": {
+                "rich_text": [
+                  {
+                    "type": "text",
+                    "text": {
+                      "content": "old"
+                    },
+                    "plain_text": "old",
+                    "annotations": {
+                      "bold": false,
+                      "italic": false,
+                      "strikethrough": false,
+                      "underline": false,
+                      "code": false,
+                      "color": "default"
+                    }
+                  }
+                ],
+                "color": "default"
+              }
+            },
+            {
+              "object": "block",
               "id": "dddd0000-0000-0000-0000-000000000012",
               "parent": {
                 "type": "page_id",

--- a/tests/test_upload_mock_api.py
+++ b/tests/test_upload_mock_api.py
@@ -896,3 +896,56 @@ def test_deeply_nested_blocks_strip_rejected_fields() -> None:
     serialized_text = json.dumps(obj=serialized)
     for field in ("archived", "in_trash", "is_archived", "has_children"):
         assert f'"{field}"' not in serialized_text
+
+
+def test_failed_append_does_not_delete_existing_blocks(
+    *,
+    respx_mock: respx.MockRouter,
+    notion_session: Session,
+) -> None:
+    """A failing append leaves the existing blocks in place.
+
+    Regression test: blocks were deleted before the replacement blocks
+    were appended, so an append failure (rate limiting, a Cloudflare WAF
+    block, a timeout) left the page erased. The append now happens first,
+    so when it fails no existing block is deleted and no content is lost.
+    """
+    deleted_block_url_path = "/v1/blocks/dddd0000-0000-0000-0000-000000000011"
+    before_delete_count = count_mock_requests(
+        mock=respx_mock,
+        method="DELETE",
+        url_path=deleted_block_url_path,
+    )
+
+    with (
+        patch.object(
+            target=ChildrenMixin,
+            attribute="append",
+            side_effect=_make_html_http_error(status_code=502),
+        ),
+        pytest.raises(expected_exception=HTTPResponseError),
+    ):
+        notion_upload.upload_to_notion(
+            session=notion_session,
+            blocks=[
+                UnoParagraph(text=text(text="same")),
+                UnoParagraph(text=text(text="new")),
+                Divider(),
+            ],
+            page_id=None,
+            parent_page_id="dddd0000-0000-0000-0000-000000000001",
+            parent_database_id=None,
+            title="Upload Title",
+            icon=None,
+            cover_path=None,
+            cover_url=None,
+            cancel_on_discussion=False,
+        )
+
+    after_delete_count = count_mock_requests(
+        mock=respx_mock,
+        method="DELETE",
+        url_path=deleted_block_url_path,
+    )
+
+    assert after_delete_count == before_delete_count


### PR DESCRIPTION
## Problem

`upload_to_notion` syncs a page by **deleting** the existing blocks that differ from the freshly built source and **then appending** the replacements. Those are two separate, non-atomic Notion API calls. If the append fails after the deletes — Notion rate limiting (429), a Cloudflare WAF block (403), a timeout — or the process is interrupted in between, the page is left with the old content **gone** and the new content **never written**. The result is a silently erased page and irrecoverable data loss.

The worst case is when the first block changes: the prefix match is 0, suffix matching is disabled, so *every* block is queued for deletion. The bot deletes the whole page, then a failing append leaves it blank. CI's retry wrapper re-runs the whole command against the now-empty page, but a persistent append failure leaves it erased.

This actually happened to a published page.

## Fix

Append the new blocks **first**, then delete the old ones.

A failure or interruption now leaves the page with both the new and the old blocks (duplicated content), which is harmless and self-heals on the next successful sync. The new blocks are inserted directly after the matching prefix and before the blocks being replaced (`after=after_block`), so a fully successful sync produces the **same final ordering** as before.

This is purely a reordering of two existing operations; no new behaviour against the real API. When `after` is set, Notion's append already returns the new blocks plus all trailing blocks, and `ultimate_notion` reconciles its cache against them — appending before the deletes simply means the not-yet-deleted blocks are part of that trailing set, which matches in production.

## Tests

- New regression test `test_failed_append_does_not_delete_existing_blocks`: a failing append must delete **no** existing blocks. It fails on the old ordering (delete count 1) and passes on the fix (delete count 0).
- The append mock for the prefix/suffix scenario now also returns the not-yet-deleted block among the trailing blocks, matching Notion's append-with-`after` response now that deletion happens afterwards.

All upload tests pass; `ruff`, `mypy`, `ty`, `pyright` clean; `pylint` 10/10.

## Follow-up (not in this PR)

Consider a guard that refuses to delete a page down to near-empty when the freshly built block count is suspiciously small, to protect against a broken/empty build erasing a good page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the core Notion sync ordering and failure behavior for published page content, but it is a targeted reorder with regression coverage rather than new API surface.
> 
> **Overview**
> **Reorders Notion page sync** in `upload_to_notion` so replacement blocks are **appended before** stale blocks are deleted, instead of delete-then-append.
> 
> Because append and delete are separate API calls, a failed or interrupted upload after deletes used to leave pages **empty** with no way to recover the old content. Appending first means a failure leaves **duplicate** old and new blocks until the next successful sync; successful runs still end with the same block order via `after=after_block`.
> 
> Adds a **newsfragment**, updates WireMock append responses to include not-yet-deleted trailing blocks, and a regression test **`test_failed_append_does_not_delete_existing_blocks`** that asserts no `DELETE` runs when `append` fails.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fba9b02d107493c53cac8f17d8071e4634883f5a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->