### PR TITLE
Remove archived-field scrubbing, require ultimate-notion 0.9.9

### DIFF
--- a/newsfragments/+require-ultimate-notion-0-9-9.change.rst
+++ b/newsfragments/+require-ultimate-notion-0-9-9.change.rst
@@ -1,0 +1,1 @@
+Require ``ultimate-notion`` 0.9.9 or newer. It strips the read-only ``archived``/``in_trash``/``is_archived``/``has_children`` fields from nested blocks and accepts the ``in_trash`` field on file uploads, so the internal workaround for these is no longer needed and has been removed.

--- a/newsfragments/+strip-nested-archived.change.rst
+++ b/newsfragments/+strip-nested-archived.change.rst
@@ -1,1 +1,0 @@
-Strip ``is_archived`` and ``has_children`` from nested blocks when uploading to Notion. Previously these fields were only removed from top-level blocks, so deeply nested blocks (such as admonitions nested inside admonitions) caused the Notion API to reject the upload with a validation error.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ dependencies = [
     "sphinxcontrib-mermaid>=1.0.0",
     "sphinxcontrib-video>=0.4.0",
     "sphinxnotes-strike>=2.0",
-    "ultimate-notion>=0.9.8",
+    "ultimate-notion>=0.9.9",
 ]
 optional-dependencies.dev = [
     "actionlint-py==1.7.12.24",

--- a/src/sphinx_notion/_upload.py
+++ b/src/sphinx_notion/_upload.py
@@ -6,11 +6,11 @@ Inspired by https://github.com/ftnext/sphinx-notion/blob/main/upload.py.
 import hashlib
 import logging
 import sys
-from collections.abc import Callable, Sequence
+from collections.abc import Sequence
 from dataclasses import dataclass
 from functools import cache
 from pathlib import Path
-from typing import TYPE_CHECKING, cast  # noqa: TID251
+from typing import TYPE_CHECKING
 from urllib.parse import urlparse
 
 import requests
@@ -32,43 +32,6 @@ if TYPE_CHECKING:
     from ultimate_notion.database import Database
 
 _LOGGER = logging.getLogger(name=__name__)
-
-# Monkey-patch: ultimate_notion includes `archived` when serializing blocks,
-# but the Notion API rejects this field on block creation/append.
-# See https://github.com/ultimate-notion/ultimate-notion/issues/186
-_original_serialize_for_api_method: Callable[
-    [UnoObjAPIBlock], dict[str, object]
-] = UnoObjAPIBlock.serialize_for_api
-
-
-def _strip_archived_fields(*, data: dict[str, object]) -> None:
-    """Recursively remove archived/in_trash/is_archived/has_children from
-    a serialized block dict.
-    """
-    data.pop("archived", None)
-    data.pop("in_trash", None)
-    data.pop("is_archived", None)
-    data.pop("has_children", None)
-    for value in data.values():
-        if not isinstance(value, dict):
-            continue
-        children = cast("dict[str, object]", value).get("children")
-        if not isinstance(children, list):
-            continue
-        for child in cast("list[dict[str, object]]", children):
-            _strip_archived_fields(data=child)
-
-
-def _block_serialize_for_api_patched(
-    self: UnoObjAPIBlock,
-) -> dict[str, object]:  # pragma: no cover - patched at module load
-    """Serialize, removing archived/in_trash fields rejected by API."""
-    data = _original_serialize_for_api_method(self)
-    _strip_archived_fields(data=data)
-    return data
-
-
-UnoObjAPIBlock.serialize_for_api = _block_serialize_for_api_patched  # type: ignore[method-assign]  # ty: ignore[invalid-assignment]
 
 _FILE_BLOCK_TYPES = (UnoImage, UnoVideo, UnoAudio, UnoPDF, UnoFile)
 _HTTP_FORBIDDEN = 403

--- a/tests/notion_sandbox/notion-wiremock-stubs.json
+++ b/tests/notion_sandbox/notion-wiremock-stubs.json
@@ -2332,6 +2332,7 @@
           "complete_url": null,
           "file_import_result": null,
           "archived": false,
+          "in_trash": false,
           "created_by": {
             "object": "user",
             "id": "71e95936-2737-4e11-b03d-f174f6f13e90",
@@ -2371,6 +2372,7 @@
           "complete_url": null,
           "file_import_result": null,
           "archived": false,
+          "in_trash": false,
           "created_by": {
             "object": "user",
             "id": "71e95936-2737-4e11-b03d-f174f6f13e90",
@@ -2410,6 +2412,7 @@
           "complete_url": null,
           "file_import_result": null,
           "archived": false,
+          "in_trash": false,
           "created_by": {
             "object": "user",
             "id": "71e95936-2737-4e11-b03d-f174f6f13e90",


### PR DESCRIPTION
ultimate-notion 0.9.9 now strips the read-only `archived`/`in_trash`/`is_archived`/`has_children` fields from nested blocks and accepts `in_trash` on file uploads, so the local `serialize_for_api` monkey-patch is redundant and is removed. This bumps the pin to `ultimate-notion>=0.9.9`, adds the now-required `in_trash` field to the `file_upload` wiremock stubs, and swaps the nested-strip newsfragment for one describing the dependency bump. Validated against the released 0.9.9: mypy and ruff clean, 212 tests pass at 100% `src` line/branch coverage, plus a live upload of nested blocks and images against real Notion. Closes #823.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Upload behavior now depends entirely on ultimate-notion 0.9.9 for API-safe block serialization; regressions would surface as Notion validation errors on nested blocks or file uploads.
> 
> **Overview**
> Bumps **`ultimate-notion`** from `>=0.9.8` to **`>=0.9.9`** and removes the local workaround in **`_upload.py`** that monkey-patched `UnoObjAPIBlock.serialize_for_api` to strip read-only fields (`archived`, `in_trash`, `is_archived`, `has_children`) from serialized blocks before Notion API calls.
> 
> That scrubbing and correct handling of **`in_trash`** on file uploads are now handled upstream in 0.9.9, so the patch and related imports (`Callable`, `cast`) are deleted. The changelog newsfragment for the nested-strip fix is replaced with one describing the dependency bump and removal of the internal workaround.
> 
> WireMock **`file_upload`** stub responses now include **`in_trash": false`** so mocks match what 0.9.9 expects when parsing upload responses.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 79dd5aaad8d253e67e8b2c84eeb21d46330e53a7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->