### PR TITLE
Bump ultimate-notion to 0.9.10

### DIFF
--- a/newsfragments/+require-ultimate-notion-0-9-10.change.rst
+++ b/newsfragments/+require-ultimate-notion-0-9-10.change.rst
@@ -1,0 +1,1 @@
+Require ``ultimate-notion`` 0.9.10 or newer, which splits deeply-nested block trees reconstructed from serialized JSON into Notion-compliant requests on ``append()`` instead of sending an over-nested request that Notion rejects with a 400.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ dependencies = [
     "sphinxcontrib-mermaid>=1.0.0",
     "sphinxcontrib-video>=0.4.0",
     "sphinxnotes-strike>=2.0",
-    "ultimate-notion>=0.9.9",
+    "ultimate-notion>=0.9.10",
 ]
 optional-dependencies.dev = [
     "actionlint-py==1.7.12.24",


### PR DESCRIPTION
Bumps the `ultimate-notion` pin from `>=0.9.9` to `>=0.9.10`. Release 0.9.10 splits deeply-nested block trees reconstructed from serialized JSON into Notion-compliant `append()` requests instead of sending an over-nested request that Notion rejects with a 400 ([upstream issue #305](https://github.com/ultimate-notion/ultimate-notion/issues/305)). Adds a changelog newsfragment for the bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency version bump only with no local code changes; risk is limited to upstream behavioral differences during Notion uploads.
> 
> **Overview**
> Raises the **`ultimate-notion`** dependency floor from **`>=0.9.9`** to **`>=0.9.10`** so installs pick up upstream handling for **deeply nested block trees** rebuilt from serialized JSON: **`append()`** now splits them into Notion-compliant requests instead of one over-nested payload that returns **HTTP 400**.
> 
> Adds a **towncrier** newsfragment documenting the requirement and the behavioral fix; no application code changes in this repository.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 99c355d449386213d00d2bc1d9858ca74e709af5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->