### PR TITLE
Tighten ty config and remove redundant suppression comments

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -439,12 +439,17 @@ enableTypeIgnoreComments = false
 reportUnnecessaryTypeIgnoreComment = true
 
 [tool.ty]
-# The Windows-only `url2pathname` deprecation needs `# ty: ignore[deprecated]`
-# on Windows but the comment is unused on POSIX, which would otherwise fail
-# the build via ``error-on-warning``.
-rules.unused-ignore-comment = "ignore"
 # Error if ty emits any warning-level diagnostics.
 terminal.error-on-warning = true
+overrides = [
+    # On Windows, ``urllib.request.url2pathname`` is re-exported from the
+    # deprecated ``nturl2path`` module, so ty reports a ``deprecated`` diagnostic
+    # for our Python 3.12 ``file://`` URI fallback there. The diagnostic does not
+    # fire on POSIX, so a ``# ty: ignore[deprecated]`` comment would be flagged as
+    # unused there. Disabling the rule for this one file keeps both platforms green
+    # without a project-wide ``unused-ignore-comment`` suppression.
+    { include = [ "src/sphinx_notion/_upload.py" ], rules.deprecated = "ignore" },
+]
 # Disable support for `type: ignore` comments
 analysis.respect-type-ignore-comments = false
 

--- a/src/_notion_scripts/upload.py
+++ b/src/_notion_scripts/upload.py
@@ -128,9 +128,8 @@ def main(
         else Session()
     )
     block_dicts = json.loads(s=file.read_text(encoding="utf-8"))
-    # See https://github.com/ultimate-notion/ultimate-notion/issues/177
     blocks = [
-        Block.wrap_obj_ref(UnoObjAPIBlock.model_validate(obj=details))  # ty: ignore[invalid-argument-type]
+        Block.wrap_obj_ref(UnoObjAPIBlock.model_validate(obj=details))
         for details in block_dicts
     ]
 

--- a/src/sphinx_notion/__init__.py
+++ b/src/sphinx_notion/__init__.py
@@ -2397,7 +2397,7 @@ def _publish_to_notion(
 
     block_dicts = json.loads(s=output_file.read_text(encoding="utf-8"))
     blocks = [
-        Block.wrap_obj_ref(UnoObjAPIBlock.model_validate(obj=details))  # ty: ignore[invalid-argument-type]
+        Block.wrap_obj_ref(UnoObjAPIBlock.model_validate(obj=details))
         for details in block_dicts
     ]
 

--- a/src/sphinx_notion/_upload.py
+++ b/src/sphinx_notion/_upload.py
@@ -43,10 +43,10 @@ def _file_uri_to_path(*, uri: str) -> Path:  # pragma: no cover
         return Path.from_uri(uri=uri)
     # pylint: disable-next=import-outside-toplevel
     from urllib.request import (  # noqa: PLC0415
-        url2pathname,  # ty: ignore[deprecated]
+        url2pathname,
     )
 
-    return Path(url2pathname(urlparse(uri).path))  # ty: ignore[deprecated]  # noqa: KW001
+    return Path(url2pathname(urlparse(uri).path))  # noqa: KW001
 
 
 @beartype
@@ -108,8 +108,7 @@ def _block_without_children(
         del serialized_block["id"]
 
     block_without_children = Block.wrap_obj_ref(
-        # See https://github.com/ultimate-notion/ultimate-notion/issues/177
-        UnoObjAPIBlock.model_validate(obj=serialized_block)  # ty: ignore[invalid-argument-type]
+        UnoObjAPIBlock.model_validate(obj=serialized_block)
     )
     assert isinstance(block_without_children, ParentBlock)
     assert not block_without_children.blocks


### PR DESCRIPTION
Replaces the project-wide `rules.unused-ignore-comment = "ignore"` in the `ty` config with a narrowly file-scoped `deprecated` rule override for `_upload.py`, since the blanket setting existed only to tolerate the Windows-only `url2pathname` deprecation yet also silently hid genuinely-unused `ty: ignore` directives. With it gone, this removes three now-redundant `# ty: ignore[invalid-argument-type]` comments on `wrap_obj_ref(model_validate(...))` (ultimate-notion issue #177 is closed and 0.9.10's types no longer need them) and the two platform-conditional `# ty: ignore[deprecated]` comments that the override now handles. No runtime behavior changes. Verified `ty` passes on Python 3.12/3.13/3.14, and mypy, pyright, pyrefly, ruff, and the full test suite (212 passed, source at 100% coverage) remain green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config and comment-only changes with no production logic touched; risk is limited to ty failing on a platform if the override is wrong.
> 
> **Overview**
> Tightens **`ty`** configuration by dropping the project-wide **`rules.unused-ignore-comment = "ignore"`** setting and replacing it with a **file-scoped** override that ignores **`deprecated`** diagnostics only in **`_upload.py`**, so Windows-only **`url2pathname`** noise is handled without hiding genuinely unused **`ty: ignore`** comments elsewhere.
> 
> Removes **five** inline **`# ty: ignore`** suppressions that are no longer needed: three **`invalid-argument-type`** comments on **`Block.wrap_obj_ref(UnoObjAPIBlock.model_validate(...))`** in the upload CLI, publish path, and **`_block_without_children`**, plus two **`deprecated`** comments around the Python 3.12 **`file://`** URI fallback. **No runtime or upload behavior changes**—type-checker hygiene only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8346791a36044b142e8e3906e55dd03e619ff48f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->