### PR TITLE
Upload files before deleting blocks to keep page intact on failure

### DIFF
--- a/newsfragments/829.change.rst
+++ b/newsfragments/829.change.rst
@@ -1,0 +1,1 @@
+Upload all of a page's files before deleting any of its existing blocks, so that a file the Notion API rejects (for example an oversized image or an SVG with an external DTD) fails the publish with the live page left intact instead of emptied.

--- a/spelling_private_dict.txt
+++ b/spelling_private_dict.txt
@@ -1,6 +1,7 @@
 Args
 CLI
 Cloudflare
+DTD
 SVG
 URI
 WAF
@@ -15,6 +16,7 @@ hardcode
 hardcodes
 href
 noqa
+oversized
 pragma
 preprocess
 pyrefly

--- a/src/sphinx_notion/_upload.py
+++ b/src/sphinx_notion/_upload.py
@@ -467,6 +467,21 @@ def upload_to_notion(  # noqa: C901, PLR0912, PLR0915
         )
         raise DiscussionsExistError(error_message)
 
+    # Upload all files before deleting any existing blocks. Publishing is
+    # not atomic: deletions are committed to Notion immediately and cannot
+    # be rolled back. If we deleted first and a file upload then failed
+    # (e.g. Notion rejects an oversized image or an SVG with an external
+    # DTD), the live page would be left with its old content already
+    # deleted and the new content never appended -- i.e. emptied. By
+    # uploading every file first, any upload failure raises here while the
+    # live page is still untouched. Do not move this after the deletion
+    # loop below.
+    _LOGGER.info("Preparing %d blocks for upload", len(blocks_to_upload))
+    block_objs_with_uploaded_files = [
+        _block_with_uploaded_file(block=block, session=session)
+        for block in blocks_to_upload
+    ]
+
     for block_index, existing_page_block in enumerate(
         iterable=blocks_to_delete
     ):
@@ -476,12 +491,6 @@ def upload_to_notion(  # noqa: C901, PLR0912, PLR0915
             len(blocks_to_delete),
         )
         existing_page_block.delete()
-
-    _LOGGER.info("Preparing %d blocks for upload", len(blocks_to_upload))
-    block_objs_with_uploaded_files = [
-        _block_with_uploaded_file(block=block, session=session)
-        for block in blocks_to_upload
-    ]
 
     if block_objs_with_uploaded_files:
         _LOGGER.info(

--- a/tests/test_upload_mock_api.py
+++ b/tests/test_upload_mock_api.py
@@ -124,6 +124,55 @@ def test_upload_deletes_and_replaces_changed_blocks(
     assert after_append_count == before_append_count + 1
 
 
+def test_failed_file_upload_leaves_existing_blocks(
+    *,
+    respx_mock: respx.MockRouter,
+    notion_session: Session,
+    parent_page_id: str,
+) -> None:
+    """A failing file upload does not delete existing page blocks.
+
+    Regression test: file uploads must happen before any existing blocks
+    are deleted, so that a rejected file leaves the live page untouched
+    rather than emptied.
+    """
+    before_delete_count = count_mock_requests(
+        mock=respx_mock,
+        method="DELETE",
+        url_path="/v1/blocks/c02fc1d3-db8b-45c5-a222-27595b15aea7",
+    )
+    upload_error = RuntimeError("File rejected by Notion")
+    with (
+        patch.object(
+            target=notion_upload,
+            attribute="_block_with_uploaded_file",
+            side_effect=upload_error,
+        ),
+        pytest.raises(expected_exception=RuntimeError, match="File rejected"),
+    ):
+        notion_upload.upload_to_notion(
+            session=notion_session,
+            blocks=[
+                UnoParagraph(text=text(text="Different content triggers sync"))
+            ],
+            page_id=None,
+            parent_page_id=parent_page_id,
+            parent_database_id=None,
+            title="Upload Title",
+            icon=None,
+            cover_path=None,
+            cover_url=None,
+            cancel_on_discussion=False,
+        )
+
+    after_delete_count = count_mock_requests(
+        mock=respx_mock,
+        method="DELETE",
+        url_path="/v1/blocks/c02fc1d3-db8b-45c5-a222-27595b15aea7",
+    )
+    assert after_delete_count == before_delete_count
+
+
 def test_upload_with_icon(
     *,
     notion_session: Session,


### PR DESCRIPTION
Fixes #829. `upload_to_notion` deleted a page's existing blocks before uploading the new blocks' files, so because Notion deletions are committed immediately and cannot be rolled back, a single rejected file upload (e.g. an oversized image or an SVG with an external DTD) left the live page emptied with no recovery within the run. This moves file uploads to run before the deletion loop, so an upload failure raises while the live page is still untouched, and adds a code comment explaining why the order must not be reversed. A regression test (`test_failed_file_upload_leaves_existing_blocks`) asserts no DELETE request is issued when a file upload fails, and a towncrier changelog fragment is included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes ordering in the core publish path for live Notion pages; behavior on success should match, but failures now fail earlier and avoid destructive partial sync.
> 
> **Overview**
> **`upload_to_notion` now uploads all file-backed blocks before it deletes any existing page blocks**, so a failed Notion file upload aborts the publish while the live page still has its current content.
> 
> Previously, deletions ran first; because Notion commits deletes immediately, a later rejection (e.g. oversized image or SVG with an external DTD) could leave the page emptied with nothing appended. Inline comments document that this order must not be reversed.
> 
> Adds regression coverage **`test_failed_file_upload_leaves_existing_blocks`** (mocked upload failure must not issue DELETE) and a towncrier fragment for #829.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1cc042110cb929ed51ab26700fa1e70a5994fd37. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->