### PR TITLE
Bump ultimate-notion to >=0.10.1 and notion-client to >=3.1

### DIFF
--- a/bootstrap-sample-env.py
+++ b/bootstrap-sample-env.py
@@ -67,7 +67,7 @@ def main(
             parent=parent,
             title="Sphinx-Notionbuilder sample linked page",
         )
-        database = session.create_db(
+        database = session.create_ds(
             parent=parent,
             title="Sphinx-Notionbuilder sample database",
             inline=True,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
     "click>=8.0.0",
     "cloup>=3.0.0",
     "docutils>=0.21",
-    "notion-client>=2.3.0,<3",
+    "notion-client>=3.1,<4",
     "requests>=2.32.5",
     "sphinx>=9,<10",
     "sphinx-iframes>=1.1.0",
@@ -48,7 +48,7 @@ dependencies = [
     "sphinxcontrib-mermaid>=1.0.0",
     "sphinxcontrib-video>=0.4.0",
     "sphinxnotes-strike>=2.0",
-    "ultimate-notion>=0.9.10,<0.10",
+    "ultimate-notion>=0.10.1,<0.11",
 ]
 optional-dependencies.dev = [
     "actionlint-py==1.7.12.24",

--- a/src/sphinx_notion/_upload.py
+++ b/src/sphinx_notion/_upload.py
@@ -29,7 +29,7 @@ from ultimate_notion.obj_api.blocks import Block as UnoObjAPIBlock
 from ultimate_notion.page import Page
 
 if TYPE_CHECKING:
-    from ultimate_notion.database import Database
+    from ultimate_notion.database import DataSource
 
 _LOGGER = logging.getLogger(name=__name__)
 
@@ -445,7 +445,7 @@ def upload_to_notion(  # noqa: C901, PLR0912, PLR0915
         _LOGGER.info("Setting page title to '%s'", title)
         page.title = title
     else:
-        parent: Page | Database
+        parent: Page | DataSource
         if parent_page_id:
             _LOGGER.info("Fetching parent page '%s'", parent_page_id)
             parent = session.get_page(page_ref=parent_page_id)
@@ -453,7 +453,7 @@ def upload_to_notion(  # noqa: C901, PLR0912, PLR0915
         else:
             assert parent_database_id is not None
             _LOGGER.info("Fetching parent database '%s'", parent_database_id)
-            parent = session.get_db(db_ref=parent_database_id)
+            parent = session.get_ds(ds_ref=parent_database_id)
             subpages = parent.get_all_pages().to_pages()
 
         pages_matching_title = [
@@ -488,7 +488,7 @@ def upload_to_notion(  # noqa: C901, PLR0912, PLR0915
     if page.subpages:
         raise PageHasSubpagesError
 
-    if page.subdbs:
+    if page.sub_dss:
         raise PageHasDatabasesError
 
     _LOGGER.info("Syncing page blocks")

--- a/tests/notion_sandbox/notion-wiremock-stubs.json
+++ b/tests/notion_sandbox/notion-wiremock-stubs.json
@@ -1607,6 +1607,67 @@
             "type": "page_id",
             "page_id": "bbbb0000-0000-0000-0000-000000000002"
           },
+          "data_sources": [
+            {
+              "id": "bbbb0000-0000-0000-0000-000000000098",
+              "name": "Inline Database"
+            }
+          ]
+        }
+      },
+      "persistent": true
+    },
+    {
+      "name": "retrieveInlineDataSource",
+      "request": {
+        "method": "GET",
+        "urlPath": "/v1/data_sources/bbbb0000-0000-0000-0000-000000000098"
+      },
+      "persistent": true,
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "jsonBody": {
+          "object": "data_source",
+          "id": "bbbb0000-0000-0000-0000-000000000098",
+          "created_time": "2023-01-10T08:00:00.000Z",
+          "last_edited_time": "2023-01-12T10:00:00.000Z",
+          "created_by": {
+            "object": "user",
+            "id": "71e95936-2737-4e11-b03d-f174f6f13e90"
+          },
+          "last_edited_by": {
+            "object": "user",
+            "id": "71e95936-2737-4e11-b03d-f174f6f13e90"
+          },
+          "title": [
+            {
+              "type": "text",
+              "text": {
+                "content": "Inline Database"
+              },
+              "plain_text": "Inline Database",
+              "annotations": {
+                "bold": false,
+                "italic": false,
+                "strikethrough": false,
+                "underline": false,
+                "code": false,
+                "color": "default"
+              }
+            }
+          ],
+          "description": [],
+          "url": "https://www.notion.so/bbbb0098",
+          "archived": false,
+          "in_trash": false,
+          "is_inline": true,
+          "parent": {
+            "type": "database_id",
+            "database_id": "bbbb0000-0000-0000-0000-000000000099"
+          },
           "properties": {
             "Name": {
               "id": "title",
@@ -1616,8 +1677,7 @@
             }
           }
         }
-      },
-      "persistent": true
+      }
     },
     {
       "name": "retrieveDiscussionParent",
@@ -2228,6 +2288,67 @@
             "type": "workspace",
             "workspace": true
           },
+          "data_sources": [
+            {
+              "id": "d5000000-0000-0000-0000-000000000001",
+              "name": "Test Database"
+            }
+          ]
+        }
+      },
+      "persistent": true
+    },
+    {
+      "name": "retrieveDataSource",
+      "request": {
+        "method": "GET",
+        "urlPath": "/v1/data_sources/d5000000-0000-0000-0000-000000000001"
+      },
+      "persistent": true,
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "jsonBody": {
+          "object": "data_source",
+          "id": "d5000000-0000-0000-0000-000000000001",
+          "created_time": "2023-01-10T08:00:00.000Z",
+          "last_edited_time": "2023-01-12T10:00:00.000Z",
+          "created_by": {
+            "object": "user",
+            "id": "71e95936-2737-4e11-b03d-f174f6f13e90"
+          },
+          "last_edited_by": {
+            "object": "user",
+            "id": "71e95936-2737-4e11-b03d-f174f6f13e90"
+          },
+          "title": [
+            {
+              "type": "text",
+              "text": {
+                "content": "Test Database"
+              },
+              "plain_text": "Test Database",
+              "annotations": {
+                "bold": false,
+                "italic": false,
+                "strikethrough": false,
+                "underline": false,
+                "code": false,
+                "color": "default"
+              }
+            }
+          ],
+          "description": [],
+          "url": "https://www.notion.so/d5000001",
+          "archived": false,
+          "in_trash": false,
+          "is_inline": false,
+          "parent": {
+            "type": "database_id",
+            "database_id": "db000000-0000-0000-0000-000000000001"
+          },
           "properties": {
             "Name": {
               "id": "title",
@@ -2237,14 +2358,79 @@
             }
           }
         }
-      },
-      "persistent": true
+      }
     },
     {
       "name": "queryDatabase",
       "request": {
         "method": "POST",
         "urlPath": "/v1/databases/db000000-0000-0000-0000-000000000001/query"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "jsonBody": {
+          "object": "list",
+          "type": "page_or_database",
+          "page_or_database": {},
+          "has_more": false,
+          "results": [
+            {
+              "object": "page",
+              "id": "59833787-2cf9-4fdf-8782-e53db20768a5",
+              "created_time": "2023-01-15T10:30:00.000Z",
+              "last_edited_time": "2023-01-16T14:22:00.000Z",
+              "created_by": {
+                "object": "user",
+                "id": "71e95936-2737-4e11-b03d-f174f6f13e90"
+              },
+              "last_edited_by": {
+                "object": "user",
+                "id": "71e95936-2737-4e11-b03d-f174f6f13e90"
+              },
+              "archived": false,
+              "in_trash": false,
+              "parent": {
+                "type": "database_id",
+                "database_id": "db000000-0000-0000-0000-000000000001"
+              },
+              "properties": {
+                "Name": {
+                  "id": "title",
+                  "type": "title",
+                  "title": [
+                    {
+                      "type": "text",
+                      "text": {
+                        "content": "Upload Title"
+                      },
+                      "plain_text": "Upload Title",
+                      "annotations": {
+                        "bold": false,
+                        "italic": false,
+                        "strikethrough": false,
+                        "underline": false,
+                        "code": false,
+                        "color": "default"
+                      }
+                    }
+                  ]
+                }
+              },
+              "url": "https://www.notion.so/Upload-Title-59833787"
+            }
+          ]
+        }
+      },
+      "persistent": true
+    },
+    {
+      "name": "queryDataSource",
+      "request": {
+        "method": "POST",
+        "urlPath": "/v1/data_sources/d5000000-0000-0000-0000-000000000001/query"
       },
       "response": {
         "status": 200,

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -225,18 +225,25 @@ def test_upload_with_page_id(
 def test_upload_page_not_found_error(
     *,
     caplog: pytest.LogCaptureFixture,
+    monkeypatch: pytest.MonkeyPatch,
     mock_api_base_url: str,
     notion_token: str,
     parent_page_id: str,
     tmp_path: Path,
 ) -> None:
     """A useful error is shown when no page with the given ID exists."""
-    # The missing page triggers a WARNING log from ``ultimate_notion``.
-    # With ``log_cli`` enabled, the live-log handler in ``pytest``
-    # suspends and resumes global capture for WARNING records, which
-    # replaces ``sys.stderr`` mid-invocation and breaks the stream
-    # capture of ``CliRunner``.  Silence the logger so
-    # ``result.output`` stays intact.
+    # The missing page triggers WARNING logs from ``notion_client`` and
+    # ``ultimate_notion``. With ``log_cli`` enabled, the live-log handler in
+    # ``pytest`` suspends and resumes global capture for WARNING records,
+    # which replaces ``sys.stderr`` mid-invocation and breaks the stream
+    # capture of ``CliRunner``.  Silence the loggers so ``result.output``
+    # stays intact.  ``notion_client`` resets its own logger level on every
+    # client construction, so disable it rather than lowering its level.
+    monkeypatch.setattr(
+        target=logging.getLogger(name="notion_client"),
+        name="disabled",
+        value=True,
+    )
     caplog.set_level(level=logging.ERROR, logger="ultimate_notion.session")
     assert notion_token
     blocks_file = _write_blocks_file(

--- a/tests/test_upload_mock_api.py
+++ b/tests/test_upload_mock_api.py
@@ -352,8 +352,8 @@ def test_upload_with_database_parent(
     respx_mock: respx.MockRouter,
 ) -> None:
     """It is possible to upload a page to a database."""
-    parent_database_id = "db000000-0000-0000-0000-000000000001"
-    query_url_path = f"/v1/databases/{parent_database_id}/query"
+    parent_database_id = "d5000000-0000-0000-0000-000000000001"
+    query_url_path = f"/v1/data_sources/{parent_database_id}/query"
 
     before_count = count_mock_requests(
         mock=respx_mock,
@@ -808,12 +808,15 @@ def test_upload_parent_block_different_children_count(
 
 def _make_html_http_error(*, status_code: int) -> HTTPResponseError:
     """Create an HTTPResponseError with an HTML response body."""
-    response = httpx.Response(
-        status_code=status_code,
-        headers={"content-type": "text/html; charset=utf-8"},
-        content=b"<html><body>Error</body></html>",
+    return HTTPResponseError(
+        code="cloudflare_waf_block",
+        status=status_code,
+        message="Error",
+        headers=httpx.Headers(
+            headers={"content-type": "text/html; charset=utf-8"}
+        ),
+        raw_body_text="<html><body>Error</body></html>",
     )
-    return HTTPResponseError(response=response)
 
 
 def test_cloudflare_waf_block(
@@ -860,12 +863,13 @@ def test_non_html_403_not_wrapped(
     parent_page_id: str,
 ) -> None:
     """HTTPResponseError with non-HTML body is re-raised unchanged."""
-    response = httpx.Response(
-        status_code=403,
-        headers={"content-type": "application/json"},
-        content=b'{"code": "restricted_resource"}',
+    json_error = HTTPResponseError(
+        code="restricted_resource",
+        status=403,
+        message="Restricted resource",
+        headers=httpx.Headers(headers={"content-type": "application/json"}),
+        raw_body_text='{"code": "restricted_resource"}',
     )
-    json_error = HTTPResponseError(response=response)
     with (
         patch.object(
             target=ChildrenMixin,
@@ -932,12 +936,15 @@ def test_file_upload_waf_block_logs_body(
     img_file.write_bytes(data=b"<svg>CREATE TABLE x (y VARCHAR(255))</svg>")
 
     waf_body = "<!DOCTYPE html><html>Sorry, you have been blocked</html>"
-    response = httpx.Response(
-        status_code=403,
-        headers={"content-type": "text/html", "cf-ray": "abc123-LHR"},
-        content=waf_body.encode(),
+    waf_error = HTTPResponseError(
+        code="cloudflare_waf_block",
+        status=403,
+        message="Blocked",
+        headers=httpx.Headers(
+            headers={"content-type": "text/html", "cf-ray": "abc123-LHR"}
+        ),
+        raw_body_text=waf_body,
     )
-    waf_error = HTTPResponseError(response=response)
     with (
         patch.object(
             target=notion_session,
@@ -984,12 +991,13 @@ def test_file_upload_other_http_error_logs_body(
     img_file.write_bytes(data=b"fake-image-data")
 
     body = '{"code": "validation_error", "message": "too large"}'
-    response = httpx.Response(
-        status_code=400,
-        headers={"content-type": "application/json"},
-        content=body.encode(),
+    http_error = HTTPResponseError(
+        code="validation_error",
+        status=400,
+        message="too large",
+        headers=httpx.Headers(headers={"content-type": "application/json"}),
+        raw_body_text=body,
     )
-    http_error = HTTPResponseError(response=response)
     with (
         patch.object(
             target=notion_session,


### PR DESCRIPTION
Bumps the `ultimate-notion` minimum to 0.10.1 (and `notion-client` to >=3.1, which 0.10 requires), without adopting new features. Both are breaking: 0.10 adopts the Notion API 2025-09-03 database/data-source split, so the upload code is ported to the renamed API (`get_ds`, `sub_dss`, `create_ds`), and notion-client 3.x changed `HTTPResponseError`'s constructor, so the test error builders and the page-not-found logger silencing are updated. New-API data-source mock stubs were added to `notion-wiremock-stubs.json` to keep the upload tests passing. Tests pass at 100% line+branch coverage and mypy is clean; the live Notion sample was also re-published successfully with the upgraded library.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the Notion publish/upload path and parent-database resolution; behavior should match the new API but wrong data-source IDs or stub gaps could break uploads.
> 
> **Overview**
> Bumps **`ultimate-notion`** to `>=0.10.1` and **`notion-client`** to `>=3.1`, aligning with Notion API **2025-09-03** where databases expose **data sources** instead of being queried directly.
> 
> Upload and bootstrap code now use **`get_ds`**, **`create_ds`**, **`DataSource`**, and **`page.sub_dss`** instead of the old database helpers. **`parent_database_id`** still names the CLI/config value, but resolution goes through the data-source API.
> 
> WireMock stubs add **`data_sources`** on database payloads plus **`/v1/data_sources/...`** retrieve and query mappings; the database-parent upload test expects queries against a **data source** ID.
> 
> Tests construct **`HTTPResponseError`** with notion-client 3.x’s keyword fields (`code`, `status`, `raw_body_text`, etc.) instead of wrapping **`httpx.Response`**. The page-not-found CLI test **disables** the **`notion_client`** logger so **`log_cli`** does not break **`CliRunner`** capture.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 19ea9c094dd2586038a14956ce4f23a9e32c0a05. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->