### PR TITLE
Add support for Notion heading level 4

### DIFF
--- a/sample/index.rst
+++ b/sample/index.rst
@@ -3,6 +3,18 @@ Heading 1 with *bold*
 
 .. contents::
 
+Headings
+~~~~~~~~
+
+Notion supports heading levels 1 to 4. The page title above is heading level 1
+and this ``Headings`` section is heading level 2.
+
+Heading Level 3
+^^^^^^^^^^^^^^^
+
+Heading Level 4
+"""""""""""""""
+
 Autodoc
 ~~~~~~~
 

--- a/src/sphinx_notion/__init__.py
+++ b/src/sphinx_notion/__init__.py
@@ -58,6 +58,9 @@ from ultimate_notion.blocks import (
 from ultimate_notion.blocks import (
     Heading3 as UnoHeading3,
 )
+from ultimate_notion.blocks import (
+    Heading4 as UnoHeading4,
+)
 from ultimate_notion.blocks import Image as UnoImage
 from ultimate_notion.blocks import LinkToPage as UnoLinkToPage
 from ultimate_notion.blocks import NumberedItem as UnoNumberedItem
@@ -1303,7 +1306,7 @@ def _(
     """
     rich_text = _create_rich_text_from_children(node=node)
 
-    max_heading_level = 3
+    max_heading_level = 4
     if section_level > max_heading_level:
         error_msg = (
             f"Notion only supports heading levels 1-{max_heading_level}, "
@@ -1316,6 +1319,7 @@ def _(
         1: UnoHeading1,
         2: UnoHeading2,
         3: UnoHeading3,
+        4: UnoHeading4,
     }
     heading_cls = heading_levels[section_level]
     return [heading_cls(text=rich_text)]

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -34,6 +34,9 @@ from ultimate_notion.blocks import (
 from ultimate_notion.blocks import (
     Heading3 as UnoHeading3,
 )
+from ultimate_notion.blocks import (
+    Heading4 as UnoHeading4,
+)
 from ultimate_notion.blocks import Image as UnoImage
 from ultimate_notion.blocks import LinkToPage as UnoLinkToPage
 from ultimate_notion.blocks import NumberedItem as UnoNumberedItem
@@ -453,6 +456,11 @@ def test_multiple_heading_levels(
         ~~~~~~~~~~~~~~~~
 
         Content under subsection.
+
+        Sub-subsection Title
+        ^^^^^^^^^^^^^^^^^^^^
+
+        Content under sub-subsection.
     """
 
     expected_blocks = [
@@ -462,6 +470,8 @@ def test_multiple_heading_levels(
         UnoParagraph(text=text(text="Content under section.")),
         UnoHeading3(text=text(text="Subsection Title")),
         UnoParagraph(text=text(text="Content under subsection.")),
+        UnoHeading4(text=text(text="Sub-subsection Title")),
+        UnoParagraph(text=text(text="Content under sub-subsection.")),
     ]
 
     _assert_rst_converts_to_notion_objects(
@@ -2554,12 +2564,12 @@ def test_literalinclude_with_caption(
     )
 
 
-def test_heading_level_4_error(
+def test_heading_level_5_error(
     *,
     make_app: Callable[..., SphinxTestApp],
     tmp_path: Path,
 ) -> None:
-    """Heading level 4+ raises a clear error message."""
+    """Heading level 5+ raises a clear error message."""
     rst_content = """
         Main Title
         ==========
@@ -2573,13 +2583,16 @@ def test_heading_level_4_error(
         Sub-subsection Title
         ^^^^^^^^^^^^^^^^^^^^
 
-        Content under sub-subsection.
+        Sub-sub-subsection Title
+        ''''''''''''''''''''''''
+
+        Content under sub-sub-subsection.
     """
 
     index_rst = tmp_path / "src" / "index.rst"
     expected_message = (
-        r"^Notion only supports heading levels 1-3, but found heading level 4 "
-        rf"on line 11 in {re.escape(pattern=str(object=index_rst))}.$"
+        r"^Notion only supports heading levels 1-4, but found heading level 5 "
+        rf"on line 14 in {re.escape(pattern=str(object=index_rst))}.$"
     )
     with pytest.raises(
         expected_exception=ValueError,


### PR DESCRIPTION
`notion` and `ultimate-notion` now support heading level 4, so this maps docutils section level 4 to `UnoHeading4` and raises the supported heading range from 1-3 to 1-4. The sample project gains a `Headings` section that demonstrates the level-4 heading, and the integration tests cover the new conversion while the error case is updated to fire on level 5 instead of level 4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized heading conversion change with tests and sample docs; no auth, publish, or data-path changes.
> 
> **Overview**
> Extends the Notion builder so **reStructuredText section level 4** maps to **`UnoHeading4`**, raising the supported heading range from **1–3** to **1–4** to match current Notion / `ultimate-notion` support.
> 
> In `_process_node_to_blocks` for `nodes.title`, `max_heading_level` is **4**, **`UnoHeading4`** is imported and added to the level→class map, and over-limit headings still raise **`ValueError`** with an updated message (**levels 1–4**).
> 
> The **sample** `index.rst` adds a **Headings** section documenting levels 1–4. **Integration tests** expect **`UnoHeading4`** for a fourth-level section; the former level-4 error test is renamed **`test_heading_level_5_error`** and asserts failure on **level 5+**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e7fc5db92d2b3edc7746f0dcafb7660df9f75d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->