### PR TITLE
Support sphinx-design tab-set / tab-item as Notion Tabs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -38,6 +38,7 @@ Add the following to ``conf.py`` to enable the extension:
 * `sphinx-simplepdf`_
 * `sphinx-iframes`_
 * `sphinx-tabs`_
+* `sphinx-design`_
 * `sphinxcontrib-text-styles`_
 * `sphinxcontrib-mermaid`_
 
@@ -54,6 +55,7 @@ To set these up, install the extensions you want to use and add them to your ``c
        "sphinx.ext.mathjax",
        "sphinx_iframes",
        "sphinx_immaterial.task_lists",
+       "sphinx_design",
        "sphinx_simplepdf",
        "sphinx_tabs.tabs",
        "sphinx_toolbox.collapse",
@@ -78,7 +80,7 @@ The following syntax is supported:
 - Block quotes
 - Callouts
 - Collapsible sections (using the ``collapse`` directive from `sphinx-toolbox`_ )
-- Tabs (using the ``tabs`` and ``tab`` directives from `sphinx-tabs`_ )
+- Tabs (using the ``tabs`` and ``tab`` directives from `sphinx-tabs`_, or the ``tab-set`` and ``tab-item`` directives from `sphinx-design`_ )
 - Rest-example blocks (using the ``rest-example`` directive from `sphinx-toolbox`_ )
 - Images (with URLs or local paths)
 - Videos (with URLs or local paths)
@@ -464,6 +466,7 @@ The committed ``sample.env`` points at the project's own demo workspace. To rege
 .. _notion-integrations: https://www.notion.so/my-integrations
 .. _published Notion page: https://www.notion.so/Sphinx-Notionbuilder-Sample-2579ce7b60a48142a556d816c657eb55
 .. _sample document source: https://raw.githubusercontent.com/adamtheturtle/sphinx-notionbuilder/refs/heads/main/sample/index.rst
+.. _sphinx-design: https://sphinx-design.readthedocs.io/
 .. _sphinx-iframes: https://pypi.org/project/sphinx-iframes/
 .. _sphinx-immaterial task_lists: https://github.com/jbms/sphinx-immaterial
 .. _sphinx-simplepdf: https://sphinx-simplepdf.readthedocs.io/

--- a/newsfragments/845.change.rst
+++ b/newsfragments/845.change.rst
@@ -1,0 +1,1 @@
+``tab-set`` and ``tab-item`` directives (from the ``sphinx-design`` extension) now convert to Notion ``Tabs`` blocks, with each tab's label and content preserved, mirroring the existing ``sphinx-tabs`` support.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ dependencies = [
     "notion-client>=3.1,<4",
     "requests>=2.32.5",
     "sphinx>=9,<10",
+    "sphinx-design>=0.6.0",
     "sphinx-iframes>=1.1.0",
     "sphinx-immaterial>=0.13.7",
     "sphinx-simplepdf>=1.6.0",
@@ -344,9 +345,10 @@ ignore = [
 ]
 
 [tool.deptry]
-# ``sphinx-tabs`` is integrated by detecting its rendered container's CSS
-# class, not by importing it, so deptry cannot see the usage.
-per_rule_ignores.DEP002 = [ "sphinx-tabs" ]
+# ``sphinx-tabs`` and ``sphinx-design`` are integrated by detecting their
+# rendered containers' CSS classes, not by importing them, so deptry cannot
+# see the usage.
+per_rule_ignores.DEP002 = [ "sphinx-design", "sphinx-tabs" ]
 optional_dependencies_dev_groups = [
     "dev",
     "release",

--- a/sample/conf.py
+++ b/sample/conf.py
@@ -15,6 +15,7 @@ extensions = [
     "sphinx_toolbox.collapse",
     "sphinx_toolbox.rest_example",
     "sphinx_tabs.tabs",
+    "sphinx_design",
     "atsphinx.audioplayer",
     "sphinx_immaterial.task_lists",
     "sphinxcontrib.mermaid",

--- a/sample/index.rst
+++ b/sample/index.rst
@@ -230,6 +230,30 @@ Tabbed content is created using the `sphinx-tabs <https://sphinx-tabs.readthedoc
 
          Like this second paragraph.
 
+Tabbed content can also be created using the `sphinx-design <https://sphinx-design.readthedocs.io/>`_ ``tab-set`` and ``tab-item`` directives, which likewise become a Notion tabs block.
+
+.. rest-example::
+
+   .. tab-set::
+
+      .. tab-item:: Python
+
+         A Python code example:
+
+         .. code-block:: python
+
+            """Python code."""
+
+            import sys
+
+            sys.stdout.write("Hello from the Python tab\n")
+
+      .. tab-item:: Notes
+
+         Tabs can hold **formatted** text and multiple paragraphs.
+
+         Like this second paragraph.
+
 Dividers
 ~~~~~~~~
 

--- a/src/sphinx_notion/__init__.py
+++ b/src/sphinx_notion/__init__.py
@@ -1833,7 +1833,7 @@ def _(
             section_level=section_level,
         )
 
-    if "sphinx-tabs" in classes:
+    if "sphinx-tabs" in classes or "sd-tab-set" in classes:
         return _process_tabs_container(
             node=node,
             section_level=section_level,
@@ -1912,11 +1912,13 @@ def _process_tabs_container(
     node: nodes.container,
     section_level: int,
 ) -> list[Block]:
-    """Process a ``sphinx-tabs`` container by creating a Notion Tabs block.
+    """Process a tabs container by creating a Notion Tabs block.
 
-    For non-HTML builders ``sphinx-tabs`` emits each tab as a container
-    holding a label container and a content (panel) container. Notion tab
-    labels are plain text, so the label is taken as the tab's text.
+    Both ``sphinx-tabs`` (``tabs``/``tab``) and ``sphinx-design``
+    (``tab-set``/``tab-item``) emit each tab for non-HTML builders as a
+    container holding a label node and a content (panel) node. Notion tab
+    labels are plain text, so the label is taken as the tab's text and the
+    panel's children become the tab's content blocks.
     """
     labels: list[str] = []
     panels: list[nodes.Element] = []

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1844,6 +1844,55 @@ def test_tabs(
     )
 
 
+def test_sphinx_design_tabs(
+    *,
+    make_app: Callable[..., SphinxTestApp],
+    tmp_path: Path,
+) -> None:
+    """``tab-set``/``tab-item`` directives become a Notion Tabs block."""
+    rst_content = """
+        .. tab-set::
+
+           .. tab-item:: Apple
+
+              Apple is a fruit.
+
+           .. tab-item:: Pear
+
+              Pear content with **formatting**.
+
+              A second pear paragraph.
+    """
+
+    tabs_block = UnoTabs(tabs=["Apple", "Pear"])
+    tabs_block[0].append(
+        blocks=[UnoParagraph(text=text(text="Apple is a fruit."))]
+    )
+    tabs_block[1].append(
+        blocks=[
+            UnoParagraph(
+                text=(
+                    text(text="Pear content with ")
+                    + text(text="formatting", bold=True)
+                    + text(text=".")
+                )
+            ),
+            UnoParagraph(text=text(text="A second pear paragraph.")),
+        ]
+    )
+
+    expected_blocks = [tabs_block]
+
+    _assert_rst_converts_to_notion_objects(
+        rst_content=rst_content,
+        expected_blocks=expected_blocks,
+        make_app=make_app,
+        tmp_path=tmp_path,
+        extensions=("sphinx_notion", "sphinx_design"),
+        expected_warnings=(),
+    )
+
+
 def test_simple_table(
     *,
     make_app: Callable[..., SphinxTestApp],


### PR DESCRIPTION
Closes #845.

sphinx-design's `tab-set`/`tab-item` directives survive for non-HTML builders with the same `[label, panel]` container structure as sphinx-tabs, so the existing tabs handler now also matches the `sd-tab-set` CSS class — no new conversion logic needed. Adds `sphinx-design` as a (CSS-class-detected) dependency with the matching deptry `DEP002` ignore, plus an integration test mirroring `test_tabs`. Rounds it out with sample-project, README, and changelog coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> No new conversion logic—only an extra CSS-class branch on the existing tabs handler—so risk is limited to docs, dependency, and test coverage.
> 
> **Overview**
> **sphinx-design** `tab-set` and `tab-item` directives are now treated like **sphinx-tabs** when building for Notion: container nodes with the `sd-tab-set` CSS class route through the same `_process_tabs_container` path as `sphinx-tabs`, producing Notion **Tabs** blocks with labels and panel content unchanged.
> 
> The change is a small detection widening plus packaging/docs: `sphinx-design>=0.6.0` is added as a dependency (with deptry `DEP002` ignore, same pattern as `sphinx-tabs`), an integration test mirrors the existing tabs test, and the README, sample `conf.py`/`index.rst`, and a news fragment document the new option.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 88772b8b2223318da97b0165b916150f934c69f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->