### PR TITLE
Make detected-only Sphinx extensions optional

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -67,6 +67,15 @@ To set these up, install the extensions you want to use and add them to your ``c
        "sphinx_notion",
    ]
 
+Most of these extensions are installed automatically with ``sphinx-notionbuilder``.
+``sphinx-tabs`` and ``sphinx-design`` are not, so to use their directives
+(``tabs``/``tab`` and ``tab-set``/``tab-item`` respectively) install them
+separately:
+
+.. code-block:: console
+
+   $ pip install sphinx-tabs sphinx-design
+
 Supported Notion Block Types
 ----------------------------
 

--- a/newsfragments/+detected-extensions-optional.change
+++ b/newsfragments/+detected-extensions-optional.change
@@ -1,0 +1,1 @@
+``sphinx-tabs`` and ``sphinx-design`` are no longer installed automatically. They are not imported by ``sphinx_notion`` (their tabs are detected from the rendered output), so install them yourself alongside the other extensions you enable in ``conf.py`` if you use the ``tabs``/``tab`` or ``tab-set``/``tab-item`` directives.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,11 +41,9 @@ dependencies = [
     "notion-client>=3.1,<4",
     "requests>=2.32.5",
     "sphinx>=9,<10",
-    "sphinx-design>=0.6.0",
     "sphinx-iframes>=1.1.0",
     "sphinx-immaterial>=0.13.7",
     "sphinx-simplepdf>=1.6.0",
-    "sphinx-tabs>=3.5.0",
     "sphinx-toolbox==4.2.0",
     "sphinxcontrib-mermaid>=1.0.0",
     "sphinxcontrib-video>=0.4.0",
@@ -85,9 +83,11 @@ optional-dependencies.dev = [
     # use it to lint shell commands in GitHub workflow files.
     "shellcheck-py==0.11.0.1",
     "shfmt-py==4.0.0",
+    "sphinx-design>=0.6.0",
     "sphinx-lint==1.0.2",
     "sphinx-pyproject==0.3.0",
     "sphinx-substitution-extensions==2026.6.17",
+    "sphinx-tabs>=3.5.0",
     "sphinxcontrib-spelling==8.0.2",
     "sphinxcontrib-text-styles==0.2.1",
     "strict-kwargs==2026.6.8.post1",
@@ -102,7 +102,9 @@ optional-dependencies.dev = [
 ]
 optional-dependencies.release = [ "check-wheel-contents==0.6.3", "towncrier==25.8.0" ]
 optional-dependencies.sample = [
+    "sphinx-design>=0.6.0",
     "sphinx-jinja==2.0.2",
+    "sphinx-tabs>=3.5.0",
     "sphinxcontrib-text-styles==0.2.1",
 ]
 urls.Source = "https://github.com/adamtheturtle/sphinx-notionbuilder"
@@ -345,10 +347,6 @@ ignore = [
 ]
 
 [tool.deptry]
-# ``sphinx-tabs`` and ``sphinx-design`` are integrated by detecting their
-# rendered containers' CSS classes, not by importing them, so deptry cannot
-# see the usage.
-per_rule_ignores.DEP002 = [ "sphinx-design", "sphinx-tabs" ]
 optional_dependencies_dev_groups = [
     "dev",
     "release",


### PR DESCRIPTION
`sphinx-tabs` and `sphinx-design` are not imported by `sphinx_notion` — their tabs are detected from rendered output via CSS classes — so they no longer need to be forced on every user. This moves them out of the runtime `dependencies` into the `dev` and `sample` extra groups, drops the now-redundant deptry `DEP002` ignore, and adds a README note (plus a changelog fragment) explaining that they must be installed separately to use their tab directives. All other extension dependencies are genuinely imported and remain unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Packaging and documentation only; no runtime code changes, though users who relied on transitive installs must add the two packages explicitly.
> 
> **Overview**
> **`sphinx-tabs`** and **`sphinx-design`** are removed from the default **`sphinx-notionbuilder`** install. They stay supported via CSS-class detection in rendered HTML, but users who enable those extensions in **`conf.py`** must **`pip install sphinx-tabs sphinx-design`** themselves.
> 
> The packages are added to the **`dev`** and **`sample`** optional dependency groups so CI and sample builds still pull them in. The deptry **`DEP002`** ignore for those packages is dropped because they are no longer undeclared runtime deps. README and a Towncrier fragment document the change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 58780f3d43e66d42c9185d759690248220eb8296. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->