### PR TITLE
Handle subscript and superscript roles

### DIFF
--- a/newsfragments/890.change.rst
+++ b/newsfragments/890.change.rst
@@ -1,0 +1,1 @@
+Standard ``:sub:`` and ``:sup:`` inline roles now render their content as plain Notion rich text, preserving nested formatting, instead of aborting the build.

--- a/sample_warnings/conf.py
+++ b/sample_warnings/conf.py
@@ -14,4 +14,4 @@ extensions = [
 
 autosummary_generate = True
 
-suppress_warnings = ["ref.notion"]
+suppress_warnings = ["ref.notion", "notion.unsupported_inline"]

--- a/sample_warnings/index.rst
+++ b/sample_warnings/index.rst
@@ -37,6 +37,19 @@ Autosummary
 
       example_module.greet
 
+
+
+Subscript and Superscript
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Standard ``:sub:`` and ``:sup:`` roles render as plain text because Notion rich
+text has no vertical-position annotation. The builder emits a suppressible
+``notion.unsupported_inline`` warning.
+
+.. rest-example::
+
+   Water is H\ :sub:`2`\ O and the area is x\ :sup:`2`.
+
 .. toctree::
 
    other

--- a/src/sphinx_notion/__init__.py
+++ b/src/sphinx_notion/__init__.py
@@ -513,6 +513,21 @@ def _(node: nodes.inline) -> Text:
 
 @beartype
 @_process_rich_text_node.register
+def _(node: nodes.subscript | nodes.superscript) -> Text:
+    """Process vertically positioned text as plain rich text."""
+    _LOGGER.warning(
+        "%s text cannot be vertically positioned by the Notion builder. "
+        "Rendering as plain text.",
+        type(node).__name__.capitalize(),
+        type="notion",
+        subtype="unsupported_inline",
+        location=node,
+    )
+    return _create_rich_text_from_children(node=node)
+
+
+@beartype
+@_process_rich_text_node.register
 def _(node: nodes.strong) -> Text:
     """Process strong nodes by creating bold text."""
     return _create_styled_text_from_node(node=node)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -409,6 +409,106 @@ def test_inline_formatting(
     )
 
 
+def test_subscript_and_superscript(
+    *,
+    make_app: Callable[..., SphinxTestApp],
+    tmp_path: Path,
+) -> None:
+    """Subscript and superscript roles render as plain text with
+    warnings.
+    """
+    rst_content = r"""
+        Water is H\ :sub:`2`\ O and the area is x\ :sup:`2`.
+    """
+
+    index_rst = tmp_path / "src" / "index.rst"
+    expected_warnings = [
+        f"{index_rst}:1:",
+        "Subscript text cannot be vertically positioned by the Notion "
+        "builder. Rendering as plain text. [notion.unsupported_inline]\n"
+        f"{index_rst}:1:",
+        "Superscript text cannot be vertically positioned by the Notion "
+        "builder. Rendering as plain text. [notion.unsupported_inline]",
+    ]
+
+    expected_blocks = [
+        UnoParagraph(text=text(text="Water is H2O and the area is x2.")),
+    ]
+
+    _assert_rst_converts_to_notion_objects(
+        rst_content=rst_content,
+        expected_blocks=expected_blocks,
+        make_app=make_app,
+        tmp_path=tmp_path,
+        expected_warnings=expected_warnings,
+    )
+
+
+def test_subscript_and_superscript_preserve_child_formatting(
+    *,
+    make_app: Callable[..., SphinxTestApp],
+    tmp_path: Path,
+) -> None:
+    """Subscript and superscript preserve nested rich text formatting."""
+    conf_py_content = """
+from docutils import nodes
+
+def setup(app):
+    def nested_subscript(
+        name, rawtext, text, lineno, inliner, options={}, content=[]
+    ):
+        del name, lineno, inliner, options, content
+        node = nodes.subscript(rawtext)
+        node += nodes.strong(rawtext, text)
+        return [node], []
+
+    def nested_superscript(
+        name, rawtext, text, lineno, inliner, options={}, content=[]
+    ):
+        del name, lineno, inliner, options, content
+        node = nodes.superscript(rawtext)
+        node += nodes.emphasis(rawtext, text)
+        return [node], []
+
+    app.add_role('nested-sub', nested_subscript)
+    app.add_role('nested-sup', nested_superscript)
+"""
+    rst_content = """
+        Nested :nested-sub:`bold` and :nested-sup:`italic` text.
+    """
+
+    index_rst = tmp_path / "src" / "index.rst"
+    expected_warnings = [
+        f"{index_rst}:1:",
+        "Subscript text cannot be vertically positioned by the Notion "
+        "builder. Rendering as plain text. [notion.unsupported_inline]\n"
+        f"{index_rst}:1:",
+        "Superscript text cannot be vertically positioned by the Notion "
+        "builder. Rendering as plain text. [notion.unsupported_inline]",
+    ]
+
+    expected_blocks = [
+        UnoParagraph(
+            text=(
+                text(text="Nested ")
+                + text(text="bold", bold=True)
+                + text(text=" and ")
+                + text(text="italic", italic=True)
+                + text(text=" text.")
+            )
+        ),
+    ]
+
+    _assert_rst_converts_to_notion_objects(
+        rst_content=rst_content,
+        expected_blocks=expected_blocks,
+        make_app=make_app,
+        tmp_path=tmp_path,
+        conf_py_content=conf_py_content,
+        expected_warnings=expected_warnings,
+    )
+
+
 def test_single_heading(
     *,
     make_app: Callable[..., SphinxTestApp],


### PR DESCRIPTION
Fixes #890.

## What changed

- register explicit rich-text conversion for docutils `subscript` and `superscript` nodes
- preserve their child rich-text annotations while falling back to plain vertical positioning
- emit a suppressible `notion.unsupported_inline` warning explaining the fallback
- add integration coverage for standard escaped-space role syntax and nested bold/italic children
- add a release-note fragment

## Why

The existing singledispatch handler covered the concrete lowercase `nodes.inline` class. Standard `:sub:` and `:sup:` roles instead produce classes inheriting `nodes.Inline`, so conversion fell through to the unsupported-node error and aborted the build.

## Impact

Documents containing chemical formulae, exponents, ordinals, and similar inline content now build successfully. All characters and nested formatting are retained; only subscript/superscript positioning is lost because Notion rich text has no equivalent annotation.

## Validation

- `uv run --extra dev pytest -s -vvv --cov-fail-under 100 --cov=src/ --cov=tests/ .` — 219 passed, 100% coverage
- all pre-commit hooks passed
- all manual hooks passed
- all pre-push lint and type-check hooks passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized rich-text dispatch change with graceful fallback and suppressible warnings; no auth, data, or API surface changes.
> 
> **Overview**
> Fixes builds that failed on standard **`:sub:`** and **`:sup:`** roles because docutils emits `subscript`/`superscript` nodes that did not match the existing `inline` rich-text handler.
> 
> The Notion builder now converts those nodes via **`_create_rich_text_from_children`**, so text and nested inline styling (e.g. bold/italic inside the role) are kept while vertical positioning is dropped. Each occurrence logs a suppressible **`notion.unsupported_inline`** warning. The warnings sample adds **`notion.unsupported_inline`** to `suppress_warnings` and documents the behavior; integration tests and a news fragment cover plain and nested cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 66bf12ce3bc15023b5339f38869608ad600539e6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->