### PR TITLE
Flatten Sphinx horizontal lists

### DIFF
--- a/newsfragments/889.change.rst
+++ b/newsfragments/889.change.rst
@@ -1,0 +1,1 @@
+Sphinx ``hlist`` directives now flatten into ordinary Notion bulleted items in source order instead of aborting the build.

--- a/newsfragments/889.change.rst
+++ b/newsfragments/889.change.rst
@@ -1,1 +1,1 @@
-Sphinx ``hlist`` directives now flatten into ordinary Notion bulleted items in source order instead of aborting the build.
+Sphinx ``hlist`` directives now flatten into ordinary Notion bulleted items with a suppressible ``notion.unsupported_layout`` warning, instead of aborting the build.

--- a/sample/index.rst
+++ b/sample/index.rst
@@ -315,22 +315,6 @@ Including Files
       :language: python
       :caption: Example **Configuration** File
 
-Horizontal Lists
-~~~~~~~~~~~~~~~~
-
-Horizontal lists are flattened into ordinary bulleted items because Notion has
-no multi-column list layout.
-
-.. rest-example::
-
-   .. hlist::
-      :columns: 2
-
-      * One
-      * Two
-      * Three
-      * Four
-
 Bullet Lists
 ~~~~~~~~~~~~
 

--- a/sample/index.rst
+++ b/sample/index.rst
@@ -315,6 +315,22 @@ Including Files
       :language: python
       :caption: Example **Configuration** File
 
+Horizontal Lists
+~~~~~~~~~~~~~~~~
+
+Horizontal lists are flattened into ordinary bulleted items because Notion has
+no multi-column list layout.
+
+.. rest-example::
+
+   .. hlist::
+      :columns: 2
+
+      * One
+      * Two
+      * Three
+      * Four
+
 Bullet Lists
 ~~~~~~~~~~~~
 

--- a/sample_warnings/conf.py
+++ b/sample_warnings/conf.py
@@ -14,4 +14,8 @@ extensions = [
 
 autosummary_generate = True
 
-suppress_warnings = ["ref.notion", "notion.unsupported_inline"]
+suppress_warnings = [
+    "ref.notion",
+    "notion.unsupported_inline",
+    "notion.unsupported_layout",
+]

--- a/sample_warnings/index.rst
+++ b/sample_warnings/index.rst
@@ -1,8 +1,8 @@
 Suppressed Warnings Sample
 ==========================
 
-This sample demonstrates cross-reference features that produce warnings with the Notion builder.
-The warnings are suppressed via ``suppress_warnings = ["ref.notion"]`` in ``conf.py``.
+This sample demonstrates features that produce warnings with the Notion builder.
+The warnings are suppressed via ``suppress_warnings`` in ``conf.py``.
 
 Cross-references
 ~~~~~~~~~~~~~~~~
@@ -49,6 +49,24 @@ text has no vertical-position annotation. The builder emits a suppressible
 .. rest-example::
 
    Water is H\ :sub:`2`\ O and the area is x\ :sup:`2`.
+
+Horizontal Lists
+~~~~~~~~~~~~~~~~
+
+Multi-column horizontal lists cannot be represented in Notion, so items are
+flattened into a single bulleted list with a suppressible
+``notion.unsupported_layout`` warning.
+
+.. rest-example::
+
+   .. hlist::
+      :columns: 2
+
+      * One
+      * Two
+      * Three
+      * Four
+
 
 .. toctree::
 

--- a/src/sphinx_notion/__init__.py
+++ b/src/sphinx_notion/__init__.py
@@ -1216,6 +1216,27 @@ def _(
 @beartype
 @_process_node_to_blocks.register
 def _(
+    node: addnodes.hlist,
+    *,
+    section_level: int,
+) -> list[Block]:
+    """Process horizontal lists as flat bulleted item blocks."""
+    result: list[Block] = []
+    for column in node.children:
+        assert isinstance(column, addnodes.hlistcol)
+        for child in column.children:
+            result.extend(
+                _process_node_to_blocks(
+                    child,
+                    section_level=section_level,
+                )
+            )
+    return result
+
+
+@beartype
+@_process_node_to_blocks.register
+def _(
     node: nodes.enumerated_list,
     *,
     section_level: int,

--- a/src/sphinx_notion/__init__.py
+++ b/src/sphinx_notion/__init__.py
@@ -1221,6 +1221,13 @@ def _(
     section_level: int,
 ) -> list[Block]:
     """Process horizontal lists as flat bulleted item blocks."""
+    _LOGGER.warning(
+        "Horizontal list columns cannot be represented by the Notion "
+        "builder. Flattening into a single bulleted list.",
+        type="notion",
+        subtype="unsupported_layout",
+        location=node,
+    )
     result: list[Block] = []
     for column in node.children:
         assert isinstance(column, addnodes.hlistcol)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1427,6 +1427,41 @@ def test_bullet_list_with_inline_formatting(
 
 
 @pytest.mark.parametrize(
+    argnames=("columns", "items"),
+    argvalues=[
+        (1, ("One", "Two", "Three")),
+        (2, ("One", "Two", "Three")),
+        (3, ("One", "Two", "Three", "Four", "Five")),
+    ],
+)
+def test_horizontal_list(
+    *,
+    columns: int,
+    items: tuple[str, ...],
+    make_app: Callable[..., SphinxTestApp],
+    tmp_path: Path,
+) -> None:
+    """Horizontal lists flatten into bulleted items in source order."""
+    list_items = "\n".join(f"   * {item}" for item in items)
+    rst_content = f"""
+.. hlist::
+   :columns: {columns}
+
+{list_items}
+    """
+
+    expected_blocks = [UnoBulletedItem(text=text(text=item)) for item in items]
+
+    _assert_rst_converts_to_notion_objects(
+        rst_content=rst_content,
+        expected_blocks=expected_blocks,
+        make_app=make_app,
+        tmp_path=tmp_path,
+        expected_warnings=(),
+    )
+
+
+@pytest.mark.parametrize(
     argnames=("admonition_type", "emoji", "background_color", "message"),
     argvalues=[
         ("note", "📝", BGColor.BLUE, "This is an important note."),

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1450,6 +1450,12 @@ def test_horizontal_list(
 {list_items}
     """
 
+    expected_warnings = [
+        "Horizontal list columns cannot be represented by the Notion "
+        "builder. Flattening into a single bulleted list. "
+        "[notion.unsupported_layout]",
+    ]
+
     expected_blocks = [UnoBulletedItem(text=text(text=item)) for item in items]
 
     _assert_rst_converts_to_notion_objects(
@@ -1457,7 +1463,7 @@ def test_horizontal_list(
         expected_blocks=expected_blocks,
         make_app=make_app,
         tmp_path=tmp_path,
-        expected_warnings=(),
+        expected_warnings=expected_warnings,
     )
 
 


### PR DESCRIPTION
Fixes #889.

## What changed

- add a block converter for Sphinx `hlist` nodes
- flatten each generated column through the existing bullet-list converter
- preserve the original source order because Sphinx distributes contiguous item ranges across columns
- add integration coverage for one, two, and three columns, including uneven item counts
- add a release-note fragment

## Why

The Notion translator had no handler for Sphinx's `addnodes.hlist` wrapper, so an otherwise ordinary list aborted the entire build with `NotImplementedError`.

## Impact

Horizontal lists now publish as ordinary Notion bulleted items. The multi-column layout is intentionally lost, while every list item and its ordering are retained.

## Validation

- `uv run --extra dev pytest -s -vvv --cov-fail-under 100 --cov=src/ --cov=tests/ .` — 220 passed, 100% coverage
- all pre-commit hooks passed
- all manual hooks passed
- all pre-push lint and type-check hooks passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to list conversion with graceful degradation and warning; no auth, security, or data-path impact.
> 
> **Overview**
> Fixes builds that hit Sphinx **`.. hlist::`** directives, which previously had no Notion translator handler and raised **`NotImplementedError`**.
> 
> The Notion builder now registers a converter for **`addnodes.hlist`** that walks each column’s children through the existing list-to-block pipeline, so output is a **single sequence of bulleted items** in source order. Multi-column layout is dropped on purpose; a suppressible **`notion.unsupported_layout`** warning documents that tradeoff.
> 
> Docs and samples add **`notion.unsupported_layout`** to **`suppress_warnings`**, a horizontal-list **`rest-example`**, a news fragment, and parametrized integration tests for 1–3 columns (including uneven item counts).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 68184944694e1cb4b8d87d5f9a724558e7a2db76. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->