### PR TITLE
Render Sphinx production lists

### DIFF
--- a/newsfragments/888.change.rst
+++ b/newsfragments/888.change.rst
@@ -1,0 +1,1 @@
+Sphinx ``productionlist`` grammar directives now render as aligned plain-text Notion code blocks instead of aborting the build.

--- a/sample/index.rst
+++ b/sample/index.rst
@@ -495,6 +495,16 @@ Downloads
 
    Download an external file :download:`https://www.w3.org/WAI/ER/tests/xhtml/testfiles/resources/pdf/dummy.pdf` here.
 
+Production Lists
+~~~~~~~~~~~~~~~~
+
+.. rest-example::
+
+   .. productionlist::
+      expression: `term` ("+" `term`)*
+      term: `NUMBER`
+      NUMBER: /[0-9]+/
+
 Mathematical Equations
 ~~~~~~~~~~~~~~~~~~~~~~
 

--- a/src/sphinx_notion/__init__.py
+++ b/src/sphinx_notion/__init__.py
@@ -1083,6 +1083,26 @@ def _(
 @beartype
 @_process_node_to_blocks.register
 def _(
+    node: addnodes.productionlist,
+    *,
+    section_level: int,
+) -> list[Block]:
+    """Process grammar productions as a plain-text code block."""
+    del section_level
+    production_text = "\n".join(
+        production.astext().rstrip() for production in node.children
+    )
+    return [
+        UnoCode(
+            text=text(text=production_text),
+            language=CodeLang.PLAIN_TEXT,
+        )
+    ]
+
+
+@beartype
+@_process_node_to_blocks.register
+def _(
     node: nodes.bullet_list,
     *,
     section_level: int,

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1065,6 +1065,39 @@ def test_code_block_language_mapping(
     )
 
 
+def test_production_list(
+    *,
+    make_app: Callable[..., SphinxTestApp],
+    tmp_path: Path,
+) -> None:
+    """Grammar productions become an aligned plain-text code block."""
+    rst_content = """
+        .. productionlist::
+           expression: `term` ("+" `term`)*
+           term: `NUMBER`
+           NUMBER: /[0-9]+/
+    """
+
+    expected_blocks = [
+        UnoCode(
+            text=text(
+                text='expression ::= term ("+" term)*\n'
+                "term       ::= NUMBER\n"
+                "NUMBER     ::= /[0-9]+/"
+            ),
+            language=CodeLang.PLAIN_TEXT,
+        )
+    ]
+
+    _assert_rst_converts_to_notion_objects(
+        rst_content=rst_content,
+        expected_blocks=expected_blocks,
+        make_app=make_app,
+        tmp_path=tmp_path,
+        expected_warnings=(),
+    )
+
+
 def test_flat_bullet_list(
     *,
     make_app: Callable[..., SphinxTestApp],


### PR DESCRIPTION
Fixes #888.

## What changed

- add a block converter for Sphinx `productionlist` nodes
- render all grammar productions in one plain-text Notion code block
- preserve Sphinx's aligned token names, `::=` separators, definitions, and production order
- collapse the container's extra separator whitespace to one newline between productions
- add integration coverage for multiple productions and cross-referenced grammar tokens
- add a release-note fragment

## Why

The Notion translator had no handler for `addnodes.productionlist`, so language and protocol documentation using this built-in directive aborted the entire build.

## Impact

Production grammars now remain readable and ordered in Notion. Internal token links degrade to their visible token names inside the code block, avoiding unsupported rich-text reference nodes.

## Validation

- `uv run --extra dev pytest -s -vvv --cov-fail-under 100 --cov=src/ --cov=tests/ .` — 218 passed, 100% coverage
- all pre-commit hooks passed
- all manual hooks passed
- all pre-push lint and type-check hooks passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, isolated addition to the node-to-block dispatcher with tests and sample docs; no auth, data, or core pipeline changes.
> 
> **Overview**
> Fixes builds that failed when docs used Sphinx’s `.. productionlist::` directive (e.g. language grammars).
> 
> The Notion builder now registers a handler for `addnodes.productionlist` that turns all productions into **one** plain-text Notion code block. Each line comes from Sphinx’s aligned production text (`::=`, token names, definitions); productions are joined with newlines. Cross-references inside productions show as visible token names only, not unsupported rich-text links.
> 
> Adds integration coverage, a sample **Production Lists** section, and a news fragment.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 809cf3129e03ff91ede91459eee4f3e86345c3c3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->