### PR TITLE
Render version change directives

### DIFF
--- a/newsfragments/887.change.rst
+++ b/newsfragments/887.change.rst
@@ -1,0 +1,1 @@
+Sphinx ``versionadded``, ``versionchanged``, and ``deprecated`` directives now render as Notion callouts with their generated labels, versions, inline formatting, and nested content preserved.

--- a/sample/index.rst
+++ b/sample/index.rst
@@ -146,6 +146,24 @@ Link to Notion Page Block
 
       .. notion-link-to-page:: {{ sample_page_id }}
 
+Version Changes
+~~~~~~~~~~~~~~~
+
+.. rest-example::
+
+   .. versionadded:: 1.2
+      Added *inline* body.
+
+      * Nested added item.
+
+   .. versionchanged:: 1.3
+      Changed **inline** body.
+
+   .. deprecated:: 1.4
+      Deprecated body.
+
+      Nested paragraph.
+
 Admonitions
 ~~~~~~~~~~~
 

--- a/src/sphinx_notion/__init__.py
+++ b/src/sphinx_notion/__init__.py
@@ -647,9 +647,13 @@ def _create_styled_text_from_node(*, node: nodes.Element) -> Text:
         *color_mapping.keys(),
         *bg_color_classes,
     }
-    # Cross-reference classes used by autosummary and autodoc.
-    # These don't affect styling as the node type (literal) handles it.
+    # Semantic classes that don't affect Notion styling. Cross-reference
+    # styling comes from literal nodes, while version status is already
+    # represented by generated text and the containing callout.
     ignored_style_classes = {
+        "added",
+        "changed",
+        "deprecated",
         "xref",
         "py",
         "py-obj",
@@ -662,6 +666,7 @@ def _create_styled_text_from_node(*, node: nodes.Element) -> Text:
         "std-option",
         "std-term",
         "std-token",
+        "versionmodified",
     }
     unsupported_styles = [
         css_class
@@ -1347,6 +1352,22 @@ def _create_admonition_callout(
             )
         )
     return [block]
+
+
+@beartype
+@_process_node_to_blocks.register
+def _(
+    node: addnodes.versionmodified,
+    *,
+    section_level: int,
+) -> list[Block]:
+    """Process version change directives as Notion callout blocks."""
+    del section_level
+    return _create_admonition_callout(
+        node=node,
+        emoji="🏷️",
+        background_color=BGColor.GRAY,
+    )
 
 
 @beartype

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1365,6 +1365,70 @@ def test_admonition_with_bullet_points(
     )
 
 
+def test_version_change_directives(
+    *,
+    make_app: Callable[..., SphinxTestApp],
+    tmp_path: Path,
+) -> None:
+    """Version change directives preserve labels, formatting, and
+    blocks.
+    """
+    rst_content = """
+        .. versionadded:: 1.2
+           Added *inline* body.
+
+           * Nested added item.
+
+        .. versionchanged:: 1.3
+           Changed **inline** body.
+
+        .. deprecated:: 1.4
+           Deprecated body.
+
+           Nested paragraph.
+    """
+
+    added = UnoCallout(
+        text=(
+            text(text="Added in version 1.2: Added ")
+            + text(text="inline", italic=True)
+            + text(text=" body.")
+        ),
+        icon=Emoji(emoji="🏷️"),
+        color=BGColor.GRAY,
+    )
+    added.append(
+        blocks=[UnoBulletedItem(text=text(text="Nested added item."))]
+    )
+
+    changed = UnoCallout(
+        text=(
+            text(text="Changed in version 1.3: Changed ")
+            + text(text="inline", bold=True)
+            + text(text=" body.")
+        ),
+        icon=Emoji(emoji="🏷️"),
+        color=BGColor.GRAY,
+    )
+
+    deprecated = UnoCallout(
+        text=text(text="Deprecated since version 1.4: Deprecated body."),
+        icon=Emoji(emoji="🏷️"),
+        color=BGColor.GRAY,
+    )
+    deprecated.append(
+        blocks=[UnoParagraph(text=text(text="Nested paragraph."))]
+    )
+
+    _assert_rst_converts_to_notion_objects(
+        rst_content=rst_content,
+        expected_blocks=[added, changed, deprecated],
+        make_app=make_app,
+        tmp_path=tmp_path,
+        expected_warnings=(),
+    )
+
+
 def test_definition_list(
     *,
     make_app: Callable[..., SphinxTestApp],


### PR DESCRIPTION
Fixes #887.

## What changed

- add a shared converter for Sphinx `versionmodified` nodes
- render `versionadded`, `versionchanged`, and `deprecated` directives as gray tag callouts
- retain Sphinx's generated status/version prefix, inline emphasis, and nested blocks
- recognize Sphinx's version-status classes as semantic metadata instead of unsupported Notion styling
- add integration coverage for all three directives with italic, bold, bullet-list, and paragraph content
- add a release-note fragment

## Why

All three built-in directives share an `addnodes.versionmodified` wrapper. The Notion translator had no handler for it, so encountering any version annotation aborted the entire build.

## Impact

Version annotations now remain visually distinct and readable in Notion. Generated labels and versions are preserved, while nested documentation content uses the existing block converters.

## Validation

- `uv run --extra dev pytest -s -vvv --cov-fail-under 100 --cov=src/ --cov=tests/ .` — 218 passed, 100% coverage
- all pre-commit hooks passed
- all manual hooks passed
- all pre-push lint and type-check hooks passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized docutils→Notion mapping and style-class allowlisting; no auth, publish, or data-path changes.
> 
> **Overview**
> Fixes builds that previously failed when docs used **`versionadded`**, **`versionchanged`**, or **`deprecated`**, because the Notion translator had no handler for Sphinx’s shared **`versionmodified`** node.
> 
> Those directives now map to **gray Notion callouts** (🏷️) via the same **`_create_admonition_callout`** path as other admonitions. Sphinx’s generated version labels, inline emphasis, and nested bullets/paragraphs are kept. Sphinx classes **`added`**, **`changed`**, **`deprecated`**, and **`versionmodified`** are treated as semantic metadata so they don’t trigger unsupported-style warnings.
> 
> Adds integration coverage, a **Version Changes** sample section, and a release-note fragment.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b0ee12897dc2b60aaf9d27857ee692fda432391. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->