### PR TITLE
Handle nested line blocks

### DIFF
--- a/newsfragments/885.change.rst
+++ b/newsfragments/885.change.rst
@@ -1,0 +1,1 @@
+Nested line blocks now flatten into Notion paragraphs with two-space indentation per nesting level, preserved line boundaries, and inline formatting instead of aborting the build.

--- a/src/sphinx_notion/__init__.py
+++ b/src/sphinx_notion/__init__.py
@@ -386,7 +386,7 @@ def _process_rich_text_node(node: nodes.Node) -> Text:
 @_process_rich_text_node.register
 def _(node: nodes.line) -> Text:
     """Process line nodes by creating rich text."""
-    return _create_styled_text_from_node(node=node) + "\n"
+    return _create_rich_text_from_children(node=node) + "\n"
 
 
 @beartype
@@ -1278,6 +1278,27 @@ def _(
 
 
 @beartype
+def _create_rich_text_from_line_block(
+    *,
+    node: nodes.line_block,
+    indentation_level: int = 0,
+) -> Text:
+    """Flatten a nested line block with deterministic indentation."""
+    rich_text = Text.from_plain_text(text="")
+    for child in node.children:
+        if isinstance(child, nodes.line):
+            rich_text += text(text="  " * indentation_level)
+            rich_text += _process_rich_text_node(child)
+        else:
+            assert isinstance(child, nodes.line_block)
+            rich_text += _create_rich_text_from_line_block(
+                node=child,
+                indentation_level=indentation_level + 1,
+            )
+    return rich_text
+
+
+@beartype
 @_process_node_to_blocks.register
 def _(
     node: nodes.title,
@@ -2030,7 +2051,7 @@ def _(
     """
     del section_level
 
-    line_text = _create_rich_text_from_children(node=node)
+    line_text = _create_rich_text_from_line_block(node=node)
     return [UnoParagraph(text=line_text)]
 
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -4266,11 +4266,7 @@ def test_line_block(
     make_app: Callable[..., SphinxTestApp],
     tmp_path: Path,
 ) -> None:
-    """
-    Line blocks (created with pipe character) become empty Notion
-    paragraph
-    blocks.
-    """
+    """Line blocks become Notion paragraphs with preserved line breaks."""
     rst_content = """
         | This is a line block
         | with multiple lines
@@ -4285,6 +4281,44 @@ def test_line_block(
             + text(text="\n")
             + text(text="preserved exactly as written")
             + text(text="\n")
+        ),
+    ]
+
+    _assert_rst_converts_to_notion_objects(
+        rst_content=rst_content,
+        expected_blocks=expected_blocks,
+        make_app=make_app,
+        tmp_path=tmp_path,
+        expected_warnings=(),
+    )
+
+
+def test_nested_line_block(
+    *,
+    make_app: Callable[..., SphinxTestApp],
+    tmp_path: Path,
+) -> None:
+    """Nested line blocks flatten with indentation and inline
+    formatting.
+    """
+    rst_content = """
+        | First line with *italic*
+        |   Indented **child** line
+        |     Deep line with ``code``
+        | Second line
+    """
+
+    expected_blocks = [
+        UnoParagraph(
+            text=(
+                text(text="First line with ")
+                + text(text="italic", italic=True)
+                + text(text="\n  Indented ")
+                + text(text="child", bold=True)
+                + text(text=" line\n    Deep line with ")
+                + text(text="code", code=True)
+                + text(text="\nSecond line\n")
+            )
         ),
     ]
 


### PR DESCRIPTION
Fixes #885.

## What changed

- recursively flatten nested `line_block` nodes into one Notion paragraph
- represent each nesting level with a deterministic two-space indentation
- preserve source order and one newline after every line
- process line children as rich text so italic, bold, code, and other inline annotations survive
- add integration coverage for two nesting levels plus mixed inline formatting
- add a release-note fragment

## Why

The existing converter sent every outer line-block child through rich-text dispatch. Nested `line_block` children are block nodes, so they fell through to the unsupported rich-text error and aborted the build. The existing `line` handler also flattened children with `astext()`, which discarded inline annotations.

## Impact

Poetry, addresses, transcripts, and similar nested line-oriented content now publish in order with visible indentation and formatting.

## Validation

- `uv run --extra dev pytest -s -vvv --cov-fail-under 100 --cov=src/ --cov=tests/ .` — 218 passed, 100% coverage
- all pre-commit hooks passed
- all manual hooks passed
- all pre-push lint and type-check hooks passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped changes to line-block and line rich-text conversion with integration tests; no auth, publish, or API surface changes.
> 
> **Overview**
> Fixes **#885** by changing how pipe-style **line blocks** are converted to Notion so nested structure no longer aborts the build.
> 
> **Line blocks** now use a new **`_create_rich_text_from_line_block`** helper that walks nested `line_block` nodes in order, prefixes each line with two spaces per nesting level, and joins lines with newlines into a single **paragraph** rich-text payload. **`nodes.line`** rich-text handling switches from styled plain text to **`_create_rich_text_from_children`**, so *italic*, **bold**, ``code``, and similar inline markup on individual lines are kept.
> 
> Integration tests cover flat line blocks and a new nested case with mixed inline formatting; a release note fragment documents the behavior change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3dfe9b76e3c80d7689a8a824a4a625d8da9c14f2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->