### PR TITLE
Render command option lists

### DIFF
--- a/newsfragments/883.change.rst
+++ b/newsfragments/883.change.rst
@@ -1,0 +1,1 @@
+Native reStructuredText option lists now render as bulleted command options with nested descriptions, preserving aliases, arguments, and inline formatting.

--- a/sample/index.rst
+++ b/sample/index.rst
@@ -38,6 +38,15 @@ Rubric
 
    Rubrics can contain inline formatting like code and emphasis.
 
+Option Lists
+~~~~~~~~~~~~
+
+.. rest-example::
+
+   -h, --help  Show command help.
+   -v, --verbose  Enable *verbose* logging.
+   --output FILE  Write output to ``FILE``.
+
 Definition Lists
 ~~~~~~~~~~~~~~~~
 

--- a/src/sphinx_notion/__init__.py
+++ b/src/sphinx_notion/__init__.py
@@ -1249,6 +1249,35 @@ def _(
 @beartype
 @_process_node_to_blocks.register
 def _(
+    node: nodes.option_list,
+    *,
+    section_level: int,
+) -> list[Block]:
+    """Process command options as bullets with nested descriptions."""
+    result: list[Block] = []
+    for list_item in node.children:
+        assert isinstance(list_item, nodes.option_list_item)
+        option_group = list_item.children[0]
+        description = list_item.children[1]
+        assert isinstance(option_group, nodes.option_group)
+        assert isinstance(description, nodes.description)
+
+        bulleted_item = UnoBulletedItem(
+            text=text(text=option_group.astext(), code=True)
+        )
+        for child in description.children:
+            child_blocks = _process_node_to_blocks(
+                child,
+                section_level=section_level,
+            )
+            bulleted_item.append(blocks=child_blocks)
+        result.append(bulleted_item)
+    return result
+
+
+@beartype
+@_process_node_to_blocks.register
+def _(
     node: nodes.topic,
     *,
     section_level: int,

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1531,6 +1531,58 @@ def test_definition_list_with_classifier(
     )
 
 
+def test_option_list(
+    *,
+    make_app: Callable[..., SphinxTestApp],
+    tmp_path: Path,
+) -> None:
+    """Option aliases, arguments, and descriptions become bullets."""
+    rst_content = """
+        -h, --help  Show command help.
+        -v, --verbose  Enable *verbose* logging.
+        --output FILE  Write output to ``FILE``.
+    """
+
+    help_item = UnoBulletedItem(text=text(text="-h, --help", code=True))
+    help_item.append(
+        blocks=[UnoParagraph(text=text(text="Show command help."))]
+    )
+
+    verbose_item = UnoBulletedItem(text=text(text="-v, --verbose", code=True))
+    verbose_item.append(
+        blocks=[
+            UnoParagraph(
+                text=(
+                    text(text="Enable ")
+                    + text(text="verbose", italic=True)
+                    + text(text=" logging.")
+                )
+            )
+        ]
+    )
+
+    output_item = UnoBulletedItem(text=text(text="--output FILE", code=True))
+    output_item.append(
+        blocks=[
+            UnoParagraph(
+                text=(
+                    text(text="Write output to ")
+                    + text(text="FILE", code=True)
+                    + text(text=".")
+                )
+            )
+        ]
+    )
+
+    _assert_rst_converts_to_notion_objects(
+        rst_content=rst_content,
+        expected_blocks=[help_item, verbose_item, output_item],
+        make_app=make_app,
+        tmp_path=tmp_path,
+        expected_warnings=(),
+    )
+
+
 def test_generic_admonition(
     *,
     make_app: Callable[..., SphinxTestApp],


### PR DESCRIPTION
Fixes #883.

## Summary

- convert native reStructuredText option lists into Notion bulleted items
- render each option group in code style, retaining short/long aliases and arguments
- place each description beneath its option so rich-text formatting and multi-block content are preserved
- add exact integration coverage for aliases, an option argument, emphasis, and inline code

## Root cause

Docutils emits compact command-line documentation as an `option_list` tree. The Notion builder had no registered block converter for that top-level node, so otherwise valid documents aborted with `NotImplementedError`.

## Validation

- `uv run --extra dev pytest -s -vvv --cov-fail-under 100 --cov=src/ --cov=tests/ .` — 218 passed, 100% coverage
- `uv run --extra dev prek run --all-files --hook-stage pre-commit`
- `uv run --extra dev prek run --all-files --hook-stage manual`
- `uv run --extra dev prek run --all-files --hook-stage pre-push`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized new node handler and tests; no auth, publish, or data-path changes.
> 
> **Overview**
> Fixes builds that previously failed with **`NotImplementedError`** when docs used native reStructuredText **option lists** (Docutils `option_list` nodes).
> 
> The Notion builder now registers a converter that maps each option to a **`UnoBulletedItem`**: the option group (short/long flags and arguments) is the bullet label in **code** style, and the description is nested underneath via the existing block pipeline so **emphasis**, **inline code**, and multi-block content stay intact—same pattern as definition lists.
> 
> Adds **`test_option_list`** integration coverage and a sample **Option Lists** section in `sample/index.rst`, plus a newsfragment for #883.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef3798173e059a39ed678fe390fb861d7697f4ea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->