### PR TITLE
Render custom field lists

### DIFF
--- a/newsfragments/882.change.rst
+++ b/newsfragments/882.change.rst
@@ -1,0 +1,1 @@
+Custom reStructuredText field lists now render as bold labeled bullets with nested bodies, preserving field order, inline formatting, and multiple paragraphs.

--- a/sample/index.rst
+++ b/sample/index.rst
@@ -54,6 +54,17 @@ Option Lists
    -v, --verbose  Enable *verbose* logging.
    --output FILE  Write output to ``FILE``.
 
+Field Lists
+~~~~~~~~~~~
+
+.. rest-example::
+
+   :Status: *Draft*
+   :Owner: Documentation Team
+   :Notes: First paragraph.
+
+           Second paragraph with ``code``.
+
 Definition Lists
 ~~~~~~~~~~~~~~~~
 

--- a/src/sphinx_notion/__init__.py
+++ b/src/sphinx_notion/__init__.py
@@ -1474,6 +1474,35 @@ def _(
 @beartype
 @_process_node_to_blocks.register
 def _(
+    node: nodes.field_list,
+    *,
+    section_level: int,
+) -> list[Block]:
+    """Process custom fields as labeled bullets with nested bodies."""
+    result: list[Block] = []
+    for field in node.children:
+        assert isinstance(field, nodes.field)
+        field_name = field.children[0]
+        field_body = field.children[1]
+        assert isinstance(field_name, nodes.field_name)
+        assert isinstance(field_body, nodes.field_body)
+
+        bulleted_item = UnoBulletedItem(
+            text=text(text=field_name.astext(), bold=True)
+        )
+        for child in field_body.children:
+            child_blocks = _process_node_to_blocks(
+                child,
+                section_level=section_level,
+            )
+            bulleted_item.append(blocks=child_blocks)
+        result.append(bulleted_item)
+    return result
+
+
+@beartype
+@_process_node_to_blocks.register
+def _(
     node: nodes.topic,
     *,
     section_level: int,

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -2108,6 +2108,67 @@ def test_option_list(
     )
 
 
+def test_custom_field_list(
+    *,
+    make_app: Callable[..., SphinxTestApp],
+    tmp_path: Path,
+) -> None:
+    """Custom fields preserve labels, formatting, and body paragraphs."""
+    rst_content = """
+        Project metadata:
+
+        :Status: *Draft*
+        :Owner: Documentation Team
+        :Notes: First paragraph.
+
+                Second paragraph with ``code``.
+
+        The rest of the document follows.
+    """
+
+    status_item = UnoBulletedItem(text=text(text="Status", bold=True))
+    status_item.append(
+        blocks=[UnoParagraph(text=text(text="Draft", italic=True))]
+    )
+
+    owner_item = UnoBulletedItem(text=text(text="Owner", bold=True))
+    owner_item.append(
+        blocks=[UnoParagraph(text=text(text="Documentation Team"))]
+    )
+
+    notes_item = UnoBulletedItem(text=text(text="Notes", bold=True))
+    notes_item.append(
+        blocks=[UnoParagraph(text=text(text="First paragraph."))]
+    )
+    notes_item.append(
+        blocks=[
+            UnoParagraph(
+                text=(
+                    text(text="Second paragraph with ")
+                    + text(text="code", code=True)
+                    + text(text=".")
+                )
+            )
+        ]
+    )
+
+    expected_blocks = [
+        UnoParagraph(text=text(text="Project metadata:")),
+        status_item,
+        owner_item,
+        notes_item,
+        UnoParagraph(text=text(text="The rest of the document follows.")),
+    ]
+
+    _assert_rst_converts_to_notion_objects(
+        rst_content=rst_content,
+        expected_blocks=expected_blocks,
+        make_app=make_app,
+        tmp_path=tmp_path,
+        expected_warnings=(),
+    )
+
+
 def test_generic_admonition(
     *,
     make_app: Callable[..., SphinxTestApp],


### PR DESCRIPTION
Fixes #882.

## Summary

- convert custom reStructuredText field lists into labeled Notion bulleted items
- emphasize field names while nesting each field body beneath its label
- preserve source ordering, inline emphasis/code, and multiple body paragraphs
- keep this conversion scoped to `field_list`; document-level `docinfo` remains separate

## Root cause

Custom fields outside document metadata are represented by Docutils as a top-level `field_list`. The Notion builder had no registered block converter for that node, so encountering one aborted the document build.

## Validation

- `uv run --extra dev pytest -s -vvv --cov-fail-under 100 --cov=src/ --cov=tests/ .` — 218 passed, 100% coverage
- `uv run --extra dev prek run --all-files --hook-stage pre-commit`
- `uv run --extra dev prek run --all-files --hook-stage manual`
- `uv run --extra dev prek run --all-files --hook-stage pre-push`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized new node handler following existing option-list/docinfo patterns; docinfo path untouched. Risk is limited to how in-body field lists render in Notion.
> 
> **Overview**
> Fixes builds that failed when RST included in-body **field lists** (`:Name: value`), which Docutils represents as `field_list` nodes the Notion builder did not handle.
> 
> The PR registers a converter that maps each field to a Notion **bulleted item**: the field name is **bold** label text, and the field body is nested blocks (multiple paragraphs, emphasis, inline ``code``, etc.) in source order. Sphinx document **docinfo** at the top of a page is unchanged and still comes from `_create_docinfo_blocks`.
> 
> Sample docs and an integration test document the behavior; a newsfragment notes the user-facing change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb08e4ee9cee086d366367923635b61617caa2f1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->