### PR TITLE
Render native footnotes

### DIFF
--- a/newsfragments/879.change.rst
+++ b/newsfragments/879.change.rst
@@ -1,0 +1,1 @@
+Native reStructuredText footnotes now render bracketed inline numbers and numbered body bullets, including auto-numbered, explicit, named, and repeated references.

--- a/sample/index.rst
+++ b/sample/index.rst
@@ -373,6 +373,17 @@ Task Lists
 
       3. [ ] Task C
 
+Footnotes
+~~~~~~~~~
+
+.. rest-example::
+
+   Auto [#]_. Explicit [1]_. Named [#note]_ and again [#note]_.
+
+   .. [#] Auto *body*.
+   .. [1] Explicit body.
+   .. [#note] Named ``body``.
+
 Block Quotes
 ~~~~~~~~~~~~
 

--- a/src/sphinx_notion/__init__.py
+++ b/src/sphinx_notion/__init__.py
@@ -499,6 +499,13 @@ def _(node: nodes.title_reference) -> Text:
 
 @beartype
 @_process_rich_text_node.register
+def _(node: nodes.footnote_reference) -> Text:
+    """Process footnote references as bracketed numbers."""
+    return text(text=f"[{node.astext()}]")
+
+
+@beartype
+@_process_rich_text_node.register
 def _(node: nodes.Text) -> Text:
     """Process Text nodes by creating plain text."""
     return text(text=node.astext())
@@ -1129,6 +1136,28 @@ def _(
                 todo_item_block.append(blocks=child_blocks)
             result.append(todo_item_block)
     return result
+
+
+@beartype
+@_process_node_to_blocks.register
+def _(
+    node: nodes.footnote,
+    *,
+    section_level: int,
+) -> list[Block]:
+    """Process footnote bodies as numbered bulleted items."""
+    label_node = node.children[0]
+    assert isinstance(label_node, nodes.label)
+    footnote_item = UnoBulletedItem(
+        text=text(text=f"[{label_node.astext()}]", bold=True)
+    )
+    for child in node.children[1:]:
+        child_blocks = _process_node_to_blocks(
+            child,
+            section_level=section_level,
+        )
+        footnote_item.append(blocks=child_blocks)
+    return [footnote_item]
 
 
 @beartype

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -589,6 +589,81 @@ def test_multiple_links(
     )
 
 
+def test_footnotes(
+    *,
+    make_app: Callable[..., SphinxTestApp],
+    tmp_path: Path,
+) -> None:
+    """Auto, explicit, and named footnotes retain references and
+    bodies.
+    """
+    rst_content = """
+        Auto [#]_. Explicit [1]_. Named [#note]_ and again [#note]_.
+
+        .. [#] Auto *body*.
+        .. [1] Explicit body.
+        .. [#note] Named ``body``.
+    """
+
+    reference_paragraph = UnoParagraph(
+        text=(
+            text(text="Auto ")
+            + text(text="[2]")
+            + text(text=". Explicit ")
+            + text(text="[1]")
+            + text(text=". Named ")
+            + text(text="[3]")
+            + text(text=" and again ")
+            + text(text="[3]")
+            + text(text=".")
+        )
+    )
+
+    auto_item = UnoBulletedItem(text=text(text="[2]", bold=True))
+    auto_item.append(
+        blocks=[
+            UnoParagraph(
+                text=(
+                    text(text="Auto ")
+                    + text(text="body", italic=True)
+                    + text(text=".")
+                )
+            )
+        ]
+    )
+
+    explicit_item = UnoBulletedItem(text=text(text="[1]", bold=True))
+    explicit_item.append(
+        blocks=[UnoParagraph(text=text(text="Explicit body."))]
+    )
+
+    named_item = UnoBulletedItem(text=text(text="[3]", bold=True))
+    named_item.append(
+        blocks=[
+            UnoParagraph(
+                text=(
+                    text(text="Named ")
+                    + text(text="body", code=True)
+                    + text(text=".")
+                )
+            )
+        ]
+    )
+
+    _assert_rst_converts_to_notion_objects(
+        rst_content=rst_content,
+        expected_blocks=[
+            reference_paragraph,
+            auto_item,
+            explicit_item,
+            named_item,
+        ],
+        make_app=make_app,
+        tmp_path=tmp_path,
+        expected_warnings=(),
+    )
+
+
 def test_link_in_heading(
     *,
     make_app: Callable[..., SphinxTestApp],
@@ -3985,23 +4060,23 @@ def test_unsupported_node_types_in_rich_text(
 ) -> None:
     """Unsupported node types in rich text processing raise ValueError."""
     rst_content = """
-        This is a test with :footnote:`footnote node`.
+        This is a test with :unsupported:`unsupported node`.
     """
 
     conf_py_content = """
 from docutils import nodes
 
 def setup(app):
-    def footnote_role(
+    def unsupported_role(
         name, rawtext, text, lineno, inliner, options={}, content=[]
     ):  # noqa: PLR0913
-        node = nodes.footnote_reference(rawtext, text)
+        node = nodes.abbreviation(rawtext, text)
         return [node], []
 
-    app.add_role('footnote', footnote_role)
+    app.add_role('unsupported', unsupported_role)
     """
     expected_message = (
-        r"^Unsupported node type within text: footnote_reference on line 1 in "
+        r"^Unsupported node type within text: abbreviation on line 1 in "
         rf"{re.escape(pattern=str(object=tmp_path / 'src' / 'index.rst'))}\.$"
     )
     with pytest.raises(expected_exception=ValueError, match=expected_message):


### PR DESCRIPTION
Fixes #879.

## Summary

- render footnote references inline as bracketed numbers
- render footnote definitions as bold-labelled bulleted items with nested body blocks
- cover automatic, explicit, named, repeated, italic, and code-formatted footnotes

## Root cause

The builder had no rich-text handler for `footnote_reference` nodes and no block handler for `footnote` nodes, so conversion aborted when it reached the first reference or body.

## Validation

- `uv run --extra dev prek run --all-files --hook-stage pre-commit`
- `uv run --extra dev pytest -s -vvv --cov-fail-under 100 --cov=src/ --cov=tests/ .` (218 passed, 100% coverage)
- `uv run --extra dev prek run --all-files --hook-stage manual`
- `uv run --extra dev prek run --all-files --hook-stage pre-push`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive docutils handlers and tests; no auth, data, or API surface changes beyond fixing previously failing footnote conversion.
> 
> **Overview**
> Adds **native RST footnote** support to the Notion builder so documents with footnotes no longer fail conversion.
> 
> **Inline references** (`footnote_reference`) render as bracketed numbers (e.g. `[1]`, `[3]`). **Footnote definitions** (`footnote`) become bulleted items with a **bold** `[n]` label and nested body blocks, preserving inline formatting in the body (italic, code, etc.). Auto-numbered, explicit, named, and repeated references are covered.
> 
> The sample docs gain a Footnotes section; a newsfragment records the change. Integration tests assert the full conversion path; the unsupported rich-text test now uses `abbreviation` instead of `footnote_reference` so footnote references are no longer treated as unsupported.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1f7d0d584e94313f36e3fa23de39254028f2a92a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->