### PR TITLE
Render block quote attributions

### DIFF
--- a/newsfragments/878.change.rst
+++ b/newsfragments/878.change.rst
@@ -1,0 +1,1 @@
+Attributed block quotes and epigraphs now retain their author in a nested paragraph instead of aborting the Notion build.

--- a/sample/index.rst
+++ b/sample/index.rst
@@ -393,6 +393,18 @@ Block Quotes
 
          Like this.
 
+   Attributed quotes render the attribution after the body:
+
+         Documentation is a love letter that you write to your future self.
+
+         -- Damian Conway
+
+   .. epigraph::
+
+      Documentation is a love letter that you write to your future self.
+
+      -- Damian Conway
+
 Tables
 ~~~~~~
 

--- a/src/sphinx_notion/__init__.py
+++ b/src/sphinx_notion/__init__.py
@@ -1069,6 +1069,19 @@ def _(
 @beartype
 @_process_node_to_blocks.register
 def _(
+    node: nodes.attribution,
+    *,
+    section_level: int,
+) -> list[Block]:
+    """Process quote attributions as nested paragraphs."""
+    del section_level
+    rich_text = text(text="— ") + _create_rich_text_from_children(node=node)
+    return [UnoParagraph(text=rich_text)]
+
+
+@beartype
+@_process_node_to_blocks.register
+def _(
     node: nodes.literal_block,
     *,
     section_level: int,

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -803,6 +803,71 @@ def test_multi_paragraph_quote(
     )
 
 
+def test_attributed_quote(
+    *,
+    make_app: Callable[..., SphinxTestApp],
+    tmp_path: Path,
+) -> None:
+    """Attributed block quotes retain their author after the quote
+    text.
+    """
+    rst_content = """
+        Some content.
+
+            Documentation is a love letter that you write to your future self.
+
+            -- Damian Conway
+    """
+    quote = UnoQuote(
+        text=text(
+            text="Documentation is a love letter that you write to your "
+            "future self."
+        )
+    )
+    quote.append(blocks=[UnoParagraph(text=text(text="— Damian Conway"))])
+
+    _assert_rst_converts_to_notion_objects(
+        rst_content=rst_content,
+        expected_blocks=[
+            UnoParagraph(text=text(text="Some content.")),
+            quote,
+        ],
+        make_app=make_app,
+        tmp_path=tmp_path,
+        expected_warnings=(),
+    )
+
+
+def test_epigraph(
+    *,
+    make_app: Callable[..., SphinxTestApp],
+    tmp_path: Path,
+) -> None:
+    """Epigraph directives retain their attribution."""
+    rst_content = """
+        .. epigraph::
+
+           Documentation is a love letter that you write to your future self.
+
+           -- Damian Conway
+    """
+    quote = UnoQuote(
+        text=text(
+            text="Documentation is a love letter that you write to your "
+            "future self."
+        )
+    )
+    quote.append(blocks=[UnoParagraph(text=text(text="— Damian Conway"))])
+
+    _assert_rst_converts_to_notion_objects(
+        rst_content=rst_content,
+        expected_blocks=[quote],
+        make_app=make_app,
+        tmp_path=tmp_path,
+        expected_warnings=(),
+    )
+
+
 def test_table_of_contents(
     *,
     make_app: Callable[..., SphinxTestApp],


### PR DESCRIPTION
Fixes #878.

## Summary

- render quote attributions as nested paragraphs prefixed with an em dash
- preserve attribution rich text and its position after the quote body
- cover both ordinary attributed block quotes and the built-in `epigraph` directive

## Root cause

The existing block-quote converter processed every child after the opening paragraph as a nested block, but `nodes.attribution` had no registered block converter and raised `NotImplementedError`.

## Validation

- `uv run --extra dev prek run --all-files --hook-stage pre-commit`
- `uv run --extra dev pytest -s -vvv --cov-fail-under 100 --cov=src/ --cov=tests/ .` (219 passed, 100% coverage)
- `uv run --extra dev prek run --all-files --hook-stage manual`
- `uv run --extra dev prek run --all-files --hook-stage pre-push`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized converter change with integration tests; no auth, data, or API surface changes.
> 
> **Overview**
> Fixes **#878** by teaching the Notion builder how to handle `nodes.attribution`, which previously had no `_process_node_to_blocks` handler and caused **`NotImplementedError`** during builds for attributed quotes and epigraphs.
> 
> Attributions are emitted as a **nested paragraph** inside the parent `UnoQuote`, with an em dash prefix (`— `) plus the attribution’s rich text, so indented block quotes with `-- Author` and `.. epigraph::` blocks keep the author line after the quote body.
> 
> Integration tests cover both cases; the sample docs’ Block Quotes section documents the behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d3350c3fd4b34b083e110a442ebc435c413ebaf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->