### PR TITLE
Preserve omitted page metadata

### DIFF
--- a/newsfragments/876.change.rst
+++ b/newsfragments/876.change.rst
@@ -1,0 +1,1 @@
+Omitting icon and cover options now preserves existing Notion page metadata instead of clearing editor-managed presentation.

--- a/src/sphinx_notion/_upload.py
+++ b/src/sphinx_notion/_upload.py
@@ -517,7 +517,7 @@ def upload_to_notion(  # noqa: C901, PLR0912, PLR0915
 
     if icon:
         _LOGGER.info("Setting page icon to '%s'", icon)
-    page.icon = Emoji(emoji=icon) if icon else None
+        page.icon = Emoji(emoji=icon)
     if cover_path:
         page.cover = _get_uploaded_cover(
             page=page, cover=cover_path, session=session
@@ -525,8 +525,6 @@ def upload_to_notion(  # noqa: C901, PLR0912, PLR0915
     elif cover_url:
         _LOGGER.info("Setting page cover to '%s'", cover_url)
         page.cover = ExternalFile(url=cover_url)
-    else:
-        page.cover = None
 
     if page.subpages:
         raise PageHasSubpagesError

--- a/tests/_wiremock.py
+++ b/tests/_wiremock.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from typing import TYPE_CHECKING
 
 from beartype import beartype
@@ -24,4 +25,31 @@ def count_mock_requests(
     for call in calls:
         if call.request.method == method and call.request.url.path == url_path:
             count += 1
+    return count
+
+
+@beartype
+def count_page_metadata_clear_requests(
+    *,
+    mock: respx.MockRouter,
+    page_id: str,
+) -> int:
+    """Count page updates that explicitly clear icon or cover metadata."""
+    page_paths = {
+        f"/v1/pages/{page_id}",
+        f"/v1/pages/{page_id.replace('-', '')}",
+    }
+    count = 0
+    calls: list[Call] = list(mock.calls)
+    for call in calls:
+        if (
+            call.request.method == "PATCH"
+            and call.request.url.path in page_paths
+        ):
+            payload: dict[str, object] = json.loads(s=call.request.content)
+            if (
+                payload.get("icon", object()) is None
+                or payload.get("cover", object()) is None
+            ):
+                count += 1
     return count

--- a/tests/notion_sandbox/notion-wiremock-stubs.json
+++ b/tests/notion_sandbox/notion-wiremock-stubs.json
@@ -132,6 +132,16 @@
           },
           "archived": false,
           "in_trash": false,
+          "icon": {
+            "type": "emoji",
+            "emoji": "\ud83d\udcdd"
+          },
+          "cover": {
+            "type": "external",
+            "external": {
+              "url": "https://example.com/cover.png"
+            }
+          },
           "parent": {
             "type": "workspace",
             "workspace": true

--- a/tests/test_publish.py
+++ b/tests/test_publish.py
@@ -11,6 +11,7 @@ from sphinx.testing.util import SphinxTestApp
 from sphinx_notion._upload import PageHasSubpagesError
 from tests._wiremock import (  # pyrefly: ignore[missing-import]
     count_mock_requests,
+    count_page_metadata_clear_requests,
 )
 
 
@@ -133,6 +134,7 @@ def test_publish_success(
             "extensions": ["sphinx_notion"],
             "notion_publish": True,
             "notion_parent_page_id": parent_page_id,
+            "notion_page_id": parent_page_id,
             "notion_page_title": "Upload Title",
             "notion_api_base_url": mock_api_base_url,
         },
@@ -143,6 +145,10 @@ def test_publish_success(
         method="PATCH",
         url_path=append_url_path,
     )
+    metadata_clears_before = count_page_metadata_clear_requests(
+        mock=respx_mock,
+        page_id=parent_page_id,
+    )
     app.build()
     assert app.statuscode == 0
     assert (
@@ -152,6 +158,13 @@ def test_publish_success(
             url_path=append_url_path,
         )
         == before_count + 1
+    )
+    assert (
+        count_page_metadata_clear_requests(
+            mock=respx_mock,
+            page_id=parent_page_id,
+        )
+        == metadata_clears_before
     )
 
 

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import Any
 
 import pytest
+import respx
 from click.testing import CliRunner, Result
 from pytest_regressions.file_regression import FileRegressionFixture
 from ultimate_notion.blocks import (
@@ -14,6 +15,7 @@ from ultimate_notion.blocks import (
 from ultimate_notion.rich_text import text
 
 from _notion_scripts.upload import main  # pylint: disable=import-private-name
+from tests._wiremock import count_page_metadata_clear_requests
 
 
 def _write_blocks_file(
@@ -197,6 +199,7 @@ def test_upload_with_page_id(
     mock_api_base_url: str,
     notion_token: str,
     parent_page_id: str,
+    respx_mock: respx.MockRouter,
     tmp_path: Path,
 ) -> None:
     """Uploading to a page given by ID reports success."""
@@ -208,6 +211,10 @@ def test_upload_with_page_id(
         ),
     )
 
+    clears_before = count_page_metadata_clear_requests(
+        mock=respx_mock,
+        page_id=parent_page_id,
+    )
     result = _invoke_upload(
         blocks_file=blocks_file,
         parent_page_id=parent_page_id,
@@ -219,6 +226,13 @@ def test_upload_with_page_id(
     assert result.output == (
         "Uploaded page: 'Upload Title' "
         "(https://www.notion.so/Upload-Title-59833787)\n"
+    )
+    assert (
+        count_page_metadata_clear_requests(
+            mock=respx_mock,
+            page_id=parent_page_id,
+        )
+        == clears_before
     )
 
 

--- a/tests/test_upload_mock_api.py
+++ b/tests/test_upload_mock_api.py
@@ -35,6 +35,7 @@ from sphinx_notion._upload import (
 )
 from tests._wiremock import (
     count_mock_requests,
+    count_page_metadata_clear_requests,
 )
 
 
@@ -44,6 +45,32 @@ def _file_upload_create_count(*, mock: respx.MockRouter) -> int:
         mock=mock,
         method="POST",
         url_path="/v1/file_uploads",
+    )
+
+
+def test_count_page_metadata_clear_requests(
+    *,
+    parent_page_id: str,
+    respx_mock: respx.MockRouter,
+) -> None:
+    """Icon and cover null updates are both recognized as clears."""
+    clears_before = count_page_metadata_clear_requests(
+        mock=respx_mock,
+        page_id=parent_page_id,
+    )
+    for payload in ({"icon": None}, {"cover": None}):
+        response = httpx.patch(
+            url=f"https://mock.notion.test/v1/pages/{parent_page_id}",
+            json=payload,
+        )
+        assert response.status_code == httpx.codes.OK
+
+    assert (
+        count_page_metadata_clear_requests(
+            mock=respx_mock,
+            page_id=parent_page_id,
+        )
+        == clears_before + 2
     )
 
 
@@ -74,6 +101,44 @@ def test_upload_to_notion_with_wiremock(
     assert len(page.blocks) == 1
     assert isinstance(page.blocks[0], UnoParagraph)
     assert page.blocks[0].rich_text == "Hello from WireMock upload test"
+
+
+def test_omitted_page_metadata_is_preserved(
+    *,
+    notion_session: Session,
+    parent_page_id: str,
+    respx_mock: respx.MockRouter,
+) -> None:
+    """Omitted icon and cover values do not clear existing metadata."""
+    clears_before = count_page_metadata_clear_requests(
+        mock=respx_mock,
+        page_id=parent_page_id,
+    )
+    page = notion_upload.upload_to_notion(
+        session=notion_session,
+        blocks=[
+            UnoParagraph(text=text(text="Hello from WireMock upload test"))
+        ],
+        page_id=parent_page_id,
+        parent_page_id=None,
+        parent_database_id=None,
+        title="Upload Title",
+        icon=None,
+        cover_path=None,
+        cover_url=None,
+        cancel_on_discussion=False,
+    )
+
+    assert page.icon == "\N{MEMO}"
+    assert isinstance(page.cover, ExternalFile)
+    assert page.cover.url == "https://example.com/cover.png"
+    assert (
+        count_page_metadata_clear_requests(
+            mock=respx_mock,
+            page_id=parent_page_id,
+        )
+        == clears_before
+    )
 
 
 def test_upload_deletes_and_replaces_changed_blocks(


### PR DESCRIPTION
Fixes #876.

## Summary

- treat omitted icon and cover values as no-ops instead of explicit clears
- retain existing behavior for explicitly supplied emoji, uploaded-file, and URL covers
- verify an existing mock page retains its editor-managed icon and cover
- verify core, CLI, and automatic publishing paths send no metadata-clearing requests with default settings

## Root cause

`upload_to_notion()` unconditionally assigned `None` to `page.icon` and `page.cover` when optional arguments were omitted. Ultimate Notion property setters immediately translated those assignments into destructive API updates.

## Validation

- `uv run --extra dev prek run --all-files --hook-stage pre-commit`
- `uv run --extra dev pytest -s -vvv --cov-fail-under 100 --cov=src/ --cov=tests/ .` (219 passed, 100% coverage)
- `uv run --extra dev prek run --all-files --hook-stage manual`
- `uv run --extra dev prek run --all-files --hook-stage pre-push`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted change to optional metadata handling with broad test coverage; no auth or block-sync logic changes.
> 
> **Overview**
> Fixes a regression where syncing docs to an existing Notion page **wiped editor-set icon and cover** whenever those options were left unset.
> 
> **`upload_to_notion()`** no longer assigns `None` to `page.icon` or `page.cover` when `icon`, `cover_path`, and `cover_url` are omitted. Ultimate Notion treated those assignments as explicit clears and PATCHed the API. Behavior is unchanged when you **do** pass an emoji icon, a local cover file, or a cover URL.
> 
> Tests add **`count_page_metadata_clear_requests`** on mocked PATCH `/v1/pages/...` payloads, seed the WireMock page with icon/cover, and assert library, CLI, and Sphinx publish paths do not send metadata-clearing updates with defaults.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b645ac3d5c35565299cbc8c5afadbc8884e74f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->