### PR TITLE
Preserve local file display names

### DIFF
--- a/newsfragments/875.change.rst
+++ b/newsfragments/875.change.rst
@@ -1,0 +1,1 @@
+Local ``notion-file`` uploads now retain their configured display name as well as their caption.

--- a/src/sphinx_notion/_upload.py
+++ b/src/sphinx_notion/_upload.py
@@ -429,7 +429,17 @@ def _block_with_uploaded_file(*, block: Block, session: Session) -> Block:
 
             _LOGGER.info("File '%s' uploaded", file_path.name)
 
-            block = block.__class__(file=uploaded_file, caption=block.caption)
+            if isinstance(block, UnoFile):
+                block = UnoFile(
+                    file=uploaded_file,
+                    name=block.name,
+                    caption=block.caption,
+                )
+            else:
+                block = block.__class__(
+                    file=uploaded_file,
+                    caption=block.caption,
+                )
 
     elif isinstance(block, ParentBlock) and block.has_children:
         new_child_blocks = [

--- a/tests/test_upload_mock_api.py
+++ b/tests/test_upload_mock_api.py
@@ -3,6 +3,7 @@
 import json
 import re
 from pathlib import Path
+from typing import TYPE_CHECKING
 from unittest.mock import patch
 
 import httpx
@@ -17,6 +18,7 @@ from ultimate_notion.blocks import (
     ChildrenMixin,
     Divider,
 )
+from ultimate_notion.blocks import File as UnoFile
 from ultimate_notion.blocks import Image as UnoImage
 from ultimate_notion.blocks import (
     Paragraph as UnoParagraph,
@@ -36,6 +38,9 @@ from sphinx_notion._upload import (
 from tests._wiremock import (
     count_mock_requests,
 )
+
+if TYPE_CHECKING:
+    from respx.models import Call
 
 
 def _file_upload_create_count(*, mock: respx.MockRouter) -> int:
@@ -465,6 +470,56 @@ def test_upload_with_file_block(
     assert str(object=uploaded_image_file.id) == (
         "ff000000-0000-0000-0000-000000000001"
     )
+
+
+def test_upload_local_file_preserves_name_and_caption(
+    *,
+    notion_session: Session,
+    parent_page_id: str,
+    respx_mock: respx.MockRouter,
+    tmp_path: Path,
+) -> None:
+    """A local file's custom presentation survives file upload."""
+    local_file = tmp_path / "archive.zip"
+    local_file.write_bytes(data=b"release-bundle")
+    append_url_path = f"/v1/blocks/{parent_page_id}/children"
+    appends_before = count_mock_requests(
+        mock=respx_mock,
+        method="PATCH",
+        url_path=append_url_path,
+    )
+
+    notion_upload.upload_to_notion(
+        session=notion_session,
+        blocks=[
+            UnoFile(
+                file=ExternalFile(url=local_file.as_uri()),
+                name="Download the release bundle",
+                caption="Current release",
+            )
+        ],
+        page_id=None,
+        parent_page_id=parent_page_id,
+        parent_database_id=None,
+        title="Upload Title",
+        icon=None,
+        cover_path=None,
+        cover_url=None,
+        cancel_on_discussion=False,
+    )
+
+    calls: list[Call] = list(respx_mock.calls)
+    append_calls = [
+        call
+        for call in calls
+        if call.request.method == "PATCH"
+        and call.request.url.path == append_url_path
+    ]
+    assert len(append_calls) == appends_before + 1
+    payload = json.loads(s=append_calls[-1].request.content)
+    uploaded_file = payload["children"][0]["file"]
+    assert uploaded_file["name"] == "Download the release bundle"
+    assert uploaded_file["caption"][0]["text"]["content"] == "Current release"
 
 
 def test_upload_with_nested_file_block(


### PR DESCRIPTION
Fixes #875.

## Summary

- preserve `UnoFile.name` when replacing a local external-file reference with an uploaded file
- continue rebuilding image, video, audio, and PDF blocks with only their supported constructor arguments
- assert the exact appended Notion API payload retains both custom name and caption

## Root cause

The generic local-file reconstruction supplied only `file` and `caption`. `UnoFile` uniquely supports a separate `name` constructor argument, so its configured display name was silently discarded during upload.

## Validation

- `uv run --extra dev prek run --all-files --hook-stage pre-commit`
- `uv run --extra dev pytest -s -vvv --cov-fail-under 100 --cov=src/ --cov=tests/ .` (218 passed, 100% coverage)
- `uv run --extra dev prek run --all-files --hook-stage manual`
- `uv run --extra dev prek run --all-files --hook-stage pre-push`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to local-file block reconstruction in the upload path; other media block types are unchanged and coverage was added.
> 
> **Overview**
> Fixes a bug where **local `notion-file` blocks lost their configured display name** after upload. Rebuilding the block after replacing a `file://` reference with a Notion uploaded file only passed `file` and `caption`; **`UnoFile` is now reconstructed with `name` as well**, while image, video, audio, and PDF blocks still use their existing constructor args.
> 
> Adds a mock-API test that asserts the append payload keeps both the custom **name** and **caption**, plus a newsfragment for the release notes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3eab806dcf029f74ca7c4be99d41569b1cf381f2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->