### PR TITLE
Preserve figure legends

### DIFF
--- a/newsfragments/873.change.rst
+++ b/newsfragments/873.change.rst
@@ -1,0 +1,1 @@
+Preserve figure legend paragraphs after the captioned image.

--- a/src/sphinx_notion/__init__.py
+++ b/src/sphinx_notion/__init__.py
@@ -1629,6 +1629,15 @@ def _(
     for child in node.children:
         if isinstance(child, nodes.caption):
             continue
+        if isinstance(child, nodes.legend):
+            for legend_child in child.children:
+                blocks.extend(
+                    _process_node_to_blocks(
+                        legend_child,
+                        section_level=section_level,
+                    )
+                )
+            continue
         if isinstance(child, nodes.image) and caption_rich_text is not None:
             image_url = child.attributes["uri"]
             assert isinstance(image_url, str)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -5222,6 +5222,40 @@ def test_figure_directive(
     )
 
 
+def test_figure_directive_with_legend(
+    *,
+    make_app: Callable[..., SphinxTestApp],
+    tmp_path: Path,
+) -> None:
+    """``figure`` directives preserve legend paragraphs after images."""
+    rst_content = """
+        .. figure:: https://www.example.com/path/to/image.png
+
+           This is a caption.
+
+           This is the first legend paragraph.
+
+           This is the second legend paragraph.
+    """
+
+    expected_blocks = [
+        UnoImage(
+            file=ExternalFile(url="https://www.example.com/path/to/image.png"),
+            caption=text(text="This is a caption."),
+        ),
+        UnoParagraph(text=text(text="This is the first legend paragraph.")),
+        UnoParagraph(text=text(text="This is the second legend paragraph.")),
+    ]
+
+    _assert_rst_converts_to_notion_objects(
+        rst_content=rst_content,
+        expected_blocks=expected_blocks,
+        make_app=make_app,
+        tmp_path=tmp_path,
+        expected_warnings=(),
+    )
+
+
 def test_figure_directive_local_image(
     *,
     make_app: Callable[..., SphinxTestApp],


### PR DESCRIPTION
Fixes #873.

## Summary

- traverse the legend wrapper emitted for figure body content
- preserve each legend child as a block immediately after the image
- cover multiple legend paragraphs and their ordering in an integration test

## Validation

- `uv run --extra dev prek run --all-files --hook-stage pre-commit`
- `uv run --extra dev pytest -s -vvv --cov-fail-under 100 --cov=src/ --cov=tests/ .` (218 passed, 100% coverage)
- `uv run --extra dev prek run --all-files --hook-stage manual`
- `uv run --extra dev prek run --all-files --hook-stage pre-push`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to figure node handling with integration test coverage; no auth, security, or publish-path changes.
> 
> **Overview**
> Fixes **#873** by emitting figure **legend** body text in the Notion build, not only the captioned image.
> 
> The figure converter now recognizes docutils **`nodes.legend`** wrappers: each legend child is passed through **`_process_node_to_blocks`** and appended to the output block list (typically as paragraphs) in source order, immediately after the **`UnoImage`** block. Captions are unchanged.
> 
> An integration test covers a **`.. figure::`** with a caption plus multiple legend paragraphs and asserts image + paragraph ordering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d8bae837e94badb1db7abefec8d9716125c1c8c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->