### PR TITLE
Preserve compound directive content

### DIFF
--- a/newsfragments/871.change.rst
+++ b/newsfragments/871.change.rst
@@ -1,0 +1,1 @@
+Preserve visible content inside compound directives.

--- a/sample/index.rst
+++ b/sample/index.rst
@@ -78,6 +78,17 @@ Describe
 
       This is a describe directive example.
 
+Compound
+~~~~~~~~
+
+.. rest-example::
+
+   .. compound::
+
+      This is the first compound paragraph.
+
+      This is the second compound paragraph.
+
 Comments
 ~~~~~~~~
 

--- a/src/sphinx_notion/__init__.py
+++ b/src/sphinx_notion/__init__.py
@@ -1268,13 +1268,19 @@ def _(
     *,
     section_level: int,
 ) -> list[Block]:
-    """Process Sphinx ``toctree`` nodes."""
-    del node
-    del section_level
-    # There are no specific Notion blocks for ``toctree`` nodes.
-    # We need to support ``toctree`` in ``index.rst``.
-    # Just ignore it.
-    return []
+    """Process compound content, except Sphinx navigation wrappers."""
+    if "toctree-wrapper" in node["classes"]:
+        return []
+
+    blocks: list[Block] = []
+    for child in node.children:
+        blocks.extend(
+            _process_node_to_blocks(
+                child,
+                section_level=section_level,
+            )
+        )
+    return blocks
 
 
 @beartype

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -865,6 +865,39 @@ def test_toctree_directive(
     )
 
 
+def test_compound_directive(
+    *,
+    make_app: Callable[..., SphinxTestApp],
+    tmp_path: Path,
+) -> None:
+    """``compound`` directives preserve their visible child blocks."""
+    rst_content = """
+        Before.
+
+        .. compound::
+
+           This is the first compound paragraph.
+
+           This is the second compound paragraph.
+
+        After.
+    """
+    expected_blocks = [
+        UnoParagraph(text=text(text="Before.")),
+        UnoParagraph(text=text(text="This is the first compound paragraph.")),
+        UnoParagraph(text=text(text="This is the second compound paragraph.")),
+        UnoParagraph(text=text(text="After.")),
+    ]
+
+    _assert_rst_converts_to_notion_objects(
+        rst_content=rst_content,
+        expected_blocks=expected_blocks,
+        make_app=make_app,
+        tmp_path=tmp_path,
+        expected_warnings=(),
+    )
+
+
 def test_simple_code_block(
     *,
     make_app: Callable[..., SphinxTestApp],


### PR DESCRIPTION
Fixes #871.

## Summary

- ignore only Sphinx compound nodes marked as `toctree-wrapper`
- recursively convert children of ordinary Docutils compound directives
- preserve multiple compound paragraphs in their original document order
- retain the existing toctree behavior in a separate regression path

## Validation

- `uv run --extra dev prek run --all-files --hook-stage pre-commit`
- `uv run --extra dev pytest -s -vvv --cov-fail-under 100 --cov=src/ --cov=tests/ .` (218 passed, 100% coverage)
- `uv run --extra dev prek run --all-files --hook-stage manual`
- `uv run --extra dev prek run --all-files --hook-stage pre-push`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to compound node handling with a regression test; toctree-wrapper behavior is unchanged.
> 
> **Overview**
> Fixes content loss for Docutils **`.. compound::`** directives in the Notion builder.
> 
> **`nodes.compound`** handling no longer drops every compound node. Sphinx **`toctree-wrapper`** compounds are still skipped (no Notion output), but ordinary compounds now **recursively convert their children** so multiple paragraphs appear in document order.
> 
> Adds an integration test and a **Compound** sample in `sample/index.rst`, plus a newsfragment for #871.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c43d805c1a2baaacab6f125d520b019dd1cf1add. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->