### PR TITLE
Restore topic directive conversion

### DIFF
--- a/newsfragments/872.change.rst
+++ b/newsfragments/872.change.rst
@@ -1,0 +1,1 @@
+Render user-authored topic directives as callouts instead of aborting the build.

--- a/sample/index.rst
+++ b/sample/index.rst
@@ -194,6 +194,17 @@ Version Changes
 Topics
 ~~~~~~
 
+Regular topics become Notion callouts. The special topic emitted by
+``.. contents::`` remains a table of contents.
+
+.. rest-example::
+
+   .. topic:: Release *notes*
+
+      This is the visible topic body.
+
+      This is the second paragraph.
+
 Admonitions
 ~~~~~~~~~~~
 

--- a/src/sphinx_notion/__init__.py
+++ b/src/sphinx_notion/__init__.py
@@ -1478,12 +1478,23 @@ def _(
     *,
     section_level: int,
 ) -> list[Block]:
-    """Process topic nodes, specifically for table of contents."""
-    del section_level  # Not used for topics
-    # Later, we can support `.. topic::` directives, likely as
-    # a callout with no icon.
-    assert "contents" in node["classes"]
-    return [UnoTableOfContents()]
+    """Process contents topics and user-authored topic directives."""
+    if "contents" in node["classes"]:
+        return [UnoTableOfContents()]
+
+    title_node = node.children[0]
+    assert isinstance(title_node, nodes.title)
+    callout = UnoCallout(
+        text=_create_rich_text_from_children(node=title_node),
+    )
+    for child in node.children[1:]:
+        callout.append(
+            blocks=_process_node_to_blocks(
+                child,
+                section_level=section_level,
+            )
+        )
+    return [callout]
 
 
 @beartype

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1158,6 +1158,38 @@ def test_table_of_contents(
     )
 
 
+def test_topic_directive(
+    *,
+    make_app: Callable[..., SphinxTestApp],
+    tmp_path: Path,
+) -> None:
+    """``topic`` directives become callout blocks with nested bodies."""
+    rst_content = """
+        .. topic:: Release *notes*
+
+           This is the visible topic body.
+
+           This is the second paragraph.
+    """
+    callout = UnoCallout(
+        text=text(text="Release ") + text(text="notes", italic=True),
+    )
+    callout.append(
+        blocks=[
+            UnoParagraph(text=text(text="This is the visible topic body.")),
+            UnoParagraph(text=text(text="This is the second paragraph.")),
+        ]
+    )
+
+    _assert_rst_converts_to_notion_objects(
+        rst_content=rst_content,
+        expected_blocks=[callout],
+        make_app=make_app,
+        tmp_path=tmp_path,
+        expected_warnings=(),
+    )
+
+
 def test_toctree_directive(
     *,
     make_app: Callable[..., SphinxTestApp],


### PR DESCRIPTION
## Summary
- restore the topic→callout converter that was missing when #912 merged
- fill in the empty Topics section in the sample project

## Test plan
- [ ] CI green
- [ ] topic directive integration test passes


Made with [Cursor](https://cursor.com)