### PR TITLE
Do not nest topic directive inside rest-example in the sample

### DIFF
--- a/sample/index.rst
+++ b/sample/index.rst
@@ -208,13 +208,11 @@ Topics
 Regular topics become Notion callouts. The special topic emitted by
 ``.. contents::`` remains a table of contents.
 
-.. rest-example::
+.. topic:: Release *notes*
 
-   .. topic:: Release *notes*
+   This is the visible topic body.
 
-      This is the visible topic body.
-
-      This is the second paragraph.
+   This is the second paragraph.
 
 Admonitions
 ~~~~~~~~~~~

--- a/sample/spelling_wordlist.txt
+++ b/sample/spelling_wordlist.txt
@@ -1,4 +1,5 @@
 callout
+callouts
 Autodoc
 Args
 Autosummary


### PR DESCRIPTION
## Problem

`main` is currently failing CI. The sample nested a `.. topic::` inside `.. rest-example::`:

```rst
.. rest-example::

   .. topic:: Release *notes*
      ...
```

docutils rejects this — `topic` is a structural element that may not appear inside a body element (the container `rest-example` renders into):

```
sample/index.rst:223: ERROR: The "topic" directive may not be used within topics or body elements. [docutils]
```

Because the sample builds with `sphinx-build -W`, this fails the **Test** and **Lint** workflows, which fails the required `completion-ci` and `completion-lint` checks — blocking every open PR.

## Fix

Show the `.. topic::` directly instead of wrapping it in `.. rest-example::`. The topic → callout conversion is still demonstrated; only the side-by-side source display is dropped for this one example.

Verified locally: `sphinx-build -W -b notion sample/ build-sample/` now succeeds.

## Upstream

The underlying `rest-example` limitation is reported upstream: sphinx-toolbox/sphinx-toolbox#219 (same class as their open #207 for `glossary`).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation sample and spelling list only; no runtime or build logic changes beyond fixing an invalid RST nesting.
> 
> **Overview**
> Unblocks failing **Test** / **Lint** CI by fixing a docutils error in the sample docs.
> 
> The **Topics** example no longer nests `.. topic::` inside `.. rest-example::` (docutils forbids `topic` inside body/container elements). The sample still documents topic → Notion callout behavior; only the side-by-side `rest-example` presentation for that block is removed.
> 
> Adds **callouts** to `spelling_wordlist.txt` for spell-check.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 35916807de9a6d268b8ab6a7c5215e7bafb48243. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->