### PR TITLE
Use filename for unnamed local uploads

### DIFF
--- a/src/sphinx_notion/_upload.py
+++ b/src/sphinx_notion/_upload.py
@@ -358,9 +358,11 @@ def _is_existing_equivalent(
         if parsed.scheme == "file":  # pragma: no cover - local duplicate check
             assert isinstance(existing_page_block, _FILE_BLOCK_TYPES)
             local_file_path = _file_uri_to_path(uri=local_block.url)
-            local_name = local_block.file_info.name
+            local_name: str | None
             if isinstance(local_block, UnoFile):
-                local_name = local_name or local_file_path.name
+                local_name = local_block.name or local_file_path.name
+            else:
+                local_name = local_block.file_info.name
 
             if (
                 not isinstance(existing_page_block.file_info, NotionFile)

--- a/src/sphinx_notion/_upload.py
+++ b/src/sphinx_notion/_upload.py
@@ -461,7 +461,7 @@ def _block_with_uploaded_file(*, block: Block, session: Session) -> Block:
             if isinstance(block, UnoFile):
                 block = UnoFile(
                     file=uploaded_file,
-                    name=block.name,
+                    name=block.name or file_path.name,
                     caption=block.caption,
                 )
             else:

--- a/src/sphinx_notion/_upload.py
+++ b/src/sphinx_notion/_upload.py
@@ -357,13 +357,14 @@ def _is_existing_equivalent(
         parsed = urlparse(url=local_block.url)
         if parsed.scheme == "file":  # pragma: no cover - local duplicate check
             assert isinstance(existing_page_block, _FILE_BLOCK_TYPES)
+            local_file_path = _file_uri_to_path(uri=local_block.url)
+            local_name = local_block.file_info.name
+            if isinstance(local_block, UnoFile):
+                local_name = local_name or local_file_path.name
 
             if (
                 not isinstance(existing_page_block.file_info, NotionFile)
-                or (
-                    existing_page_block.file_info.name
-                    != local_block.file_info.name
-                )
+                or (existing_page_block.file_info.name != local_name)
                 or (
                     existing_page_block.file_info.caption
                     != local_block.file_info.caption
@@ -371,7 +372,6 @@ def _is_existing_equivalent(
             ):
                 return False
 
-            local_file_path = _file_uri_to_path(uri=local_block.url)
             return _files_match(
                 existing_file_url=existing_page_block.file_info.url,
                 local_file_path=local_file_path,

--- a/tests/notion_sandbox/notion-wiremock-stubs.json
+++ b/tests/notion_sandbox/notion-wiremock-stubs.json
@@ -3833,14 +3833,15 @@
               "has_children": false,
               "archived": false,
               "in_trash": false,
-              "type": "image",
-              "image": {
+              "type": "file",
+              "file": {
                 "type": "file",
                 "file": {
                   "url": "https://prod-files-secure.s3.us-west-2.amazonaws.com/test.png",
                   "expiry_time": "2025-01-01T00:00:00.000Z"
                 },
-                "caption": []
+                "caption": [],
+                "name": "test.png"
               }
             }
           ]
@@ -3877,12 +3878,14 @@
               "has_children": false,
               "archived": false,
               "in_trash": false,
-              "type": "image",
-              "image": {
+              "type": "file",
+              "file": {
                 "type": "file_upload",
                 "file_upload": {
                   "id": "ff000000-0000-0000-0000-000000000001"
-                }
+                },
+                "caption": [],
+                "name": "test.png"
               }
             }
           ]
@@ -3913,14 +3916,15 @@
           "has_children": false,
           "archived": true,
           "in_trash": true,
-          "type": "image",
-          "image": {
+          "type": "file",
+          "file": {
             "type": "file",
             "file": {
               "url": "https://prod-files-secure.s3.us-west-2.amazonaws.com/test.png",
               "expiry_time": "2025-01-01T00:00:00.000Z"
             },
-            "caption": []
+            "caption": [],
+            "name": "test.png"
           }
         }
       },

--- a/tests/test_upload_mock_api.py
+++ b/tests/test_upload_mock_api.py
@@ -908,6 +908,42 @@ def test_upload_local_file_preserves_name_and_caption(
     assert uploaded_file["caption"][0]["text"]["content"] == "Current release"
 
 
+def test_upload_local_file_uses_filename_when_name_is_missing(
+    *,
+    notion_session: Session,
+    parent_page_id: str,
+    respx_mock: respx.MockRouter,
+    tmp_path: Path,
+) -> None:
+    """A local file without a display name uses its base name."""
+    local_file = tmp_path / "archive.zip"
+    local_file.write_bytes(data=b"release-bundle")
+    append_url_path = f"/v1/blocks/{parent_page_id}/children"
+
+    notion_upload.upload_to_notion(
+        session=notion_session,
+        blocks=[UnoFile(file=ExternalFile(url=local_file.as_uri()))],
+        page_id=None,
+        parent_page_id=parent_page_id,
+        parent_database_id=None,
+        title="Upload Title",
+        icon=None,
+        cover_path=None,
+        cover_url=None,
+        cancel_on_discussion=False,
+    )
+
+    calls: list[Call] = list(respx_mock.calls)
+    append_calls = [
+        call
+        for call in calls
+        if call.request.method == "PATCH"
+        and call.request.url.path == append_url_path
+    ]
+    payload = json.loads(s=append_calls[-1].request.content)
+    assert payload["children"][0]["file"]["name"] == "archive.zip"
+
+
 def test_upload_with_nested_file_block(
     *,
     notion_session: Session,

--- a/tests/test_upload_mock_api.py
+++ b/tests/test_upload_mock_api.py
@@ -10,9 +10,10 @@ from unittest.mock import MagicMock, patch
 
 import httpx
 import pytest
+import requests
 import respx
 from notion_client.errors import HTTPResponseError
-from ultimate_notion import ExternalFile, NotionFile, Session
+from ultimate_notion import ExternalFile, Session
 from ultimate_notion.blocks import (
     Block,
     BulletedItem,
@@ -945,20 +946,22 @@ def test_upload_local_file_uses_filename_when_name_is_missing(
 
 
 @pytest.mark.parametrize(
-    argnames=("local_name", "uploaded_name"),
+    argnames="local_name",
     argvalues=[
-        (None, "archive.zip"),
-        ("Download the release", "Download the release"),
+        None,
+        "test.png",
     ],
 )
-def test_local_file_matches_uploaded_name(
+def test_upload_matching_local_file_is_unchanged(
     *,
     local_name: str | None,
-    uploaded_name: str,
+    notion_session: Session,
+    respx_mock: respx.MockRouter,
     tmp_path: Path,
 ) -> None:
-    """Diff sync compares the same display name used for upload."""
-    local_file = tmp_path / "archive.zip"
+    """A matching local file is not uploaded again."""
+    local_file = tmp_path / "test.png"
+    local_file.write_bytes(data=b"image-data")
     if local_name is None:
         local_block = UnoFile(file=ExternalFile(url=local_file.as_uri()))
     else:
@@ -966,23 +969,30 @@ def test_local_file_matches_uploaded_name(
             file=ExternalFile(url=local_file.as_uri()),
             name=local_name,
         )
-    existing_block = UnoFile(
-        file=NotionFile(
-            url="https://example.com/archive.zip",
-            name=uploaded_name,
-        )
-    )
+    uploads_before = _file_upload_create_count(mock=respx_mock)
 
+    response = MagicMock()
+    response.__enter__.return_value = response
+    response.iter_content.return_value = [b"image-data"]
     with patch.object(
-        target=notion_upload,
-        attribute="_files_match",
-        return_value=True,
+        target=requests,
+        attribute="get",
+        return_value=response,
     ):
-        # pylint: disable-next=protected-access
-        assert notion_upload._is_existing_equivalent(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
-            existing_page_block=existing_block,
-            local_block=local_block,
+        notion_upload.upload_to_notion(
+            session=notion_session,
+            blocks=[local_block],
+            page_id=None,
+            parent_page_id="eeee0000-0000-0000-0000-000000000001",
+            parent_database_id=None,
+            title="Upload Title",
+            icon=None,
+            cover_path=None,
+            cover_url=None,
+            cancel_on_discussion=False,
         )
+
+    assert _file_upload_create_count(mock=respx_mock) == uploads_before
 
 
 def test_upload_with_nested_file_block(
@@ -1084,8 +1094,8 @@ def test_upload_file_block_name_mismatch(
     tmp_path: Path,
 ) -> None:
     """File block with name mismatch triggers re-upload."""
-    img_file = tmp_path / "different.png"
-    img_file.write_bytes(data=b"image-data")
+    local_file = tmp_path / "test.png"
+    local_file.write_bytes(data=b"image-data")
 
     before_upload_count = _file_upload_create_count(
         mock=respx_mock,
@@ -1093,11 +1103,11 @@ def test_upload_file_block_name_mismatch(
     notion_upload.upload_to_notion(
         session=notion_session,
         blocks=[
-            UnoImage(
+            UnoFile(
                 file=ExternalFile(
-                    url=img_file.as_uri(),
-                    name="different.png",
+                    url=local_file.as_uri(),
                 ),
+                name="Download the image",
             ),
         ],
         page_id=None,
@@ -1123,8 +1133,8 @@ def test_upload_file_block_caption_mismatch(
     tmp_path: Path,
 ) -> None:
     """File block with caption mismatch triggers re-upload."""
-    img_file = tmp_path / "test.png"
-    img_file.write_bytes(data=b"image-data")
+    local_file = tmp_path / "test.png"
+    local_file.write_bytes(data=b"image-data")
 
     before_upload_count = _file_upload_create_count(
         mock=respx_mock,
@@ -1132,8 +1142,8 @@ def test_upload_file_block_caption_mismatch(
     notion_upload.upload_to_notion(
         session=notion_session,
         blocks=[
-            UnoImage(
-                file=ExternalFile(url=img_file.as_uri()),
+            UnoFile(
+                file=ExternalFile(url=local_file.as_uri()),
                 caption="new caption",
             ),
         ],

--- a/tests/test_upload_mock_api.py
+++ b/tests/test_upload_mock_api.py
@@ -12,7 +12,7 @@ import httpx
 import pytest
 import respx
 from notion_client.errors import HTTPResponseError
-from ultimate_notion import ExternalFile, Session
+from ultimate_notion import ExternalFile, NotionFile, Session
 from ultimate_notion.blocks import (
     Block,
     BulletedItem,
@@ -942,6 +942,32 @@ def test_upload_local_file_uses_filename_when_name_is_missing(
     ]
     payload = json.loads(s=append_calls[-1].request.content)
     assert payload["children"][0]["file"]["name"] == "archive.zip"
+
+
+def test_unnamed_local_file_matches_uploaded_filename(
+    *,
+    tmp_path: Path,
+) -> None:
+    """The filename fallback does not trigger another upload."""
+    local_file = tmp_path / "archive.zip"
+    local_block = UnoFile(file=ExternalFile(url=local_file.as_uri()))
+    existing_block = UnoFile(
+        file=NotionFile(
+            url="https://example.com/archive.zip",
+            name="archive.zip",
+        )
+    )
+
+    with patch.object(
+        target=notion_upload,
+        attribute="_files_match",
+        return_value=True,
+    ):
+        # pylint: disable-next=protected-access
+        assert notion_upload._is_existing_equivalent(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+            existing_page_block=existing_block,
+            local_block=local_block,
+        )
 
 
 def test_upload_with_nested_file_block(

--- a/tests/test_upload_mock_api.py
+++ b/tests/test_upload_mock_api.py
@@ -944,17 +944,32 @@ def test_upload_local_file_uses_filename_when_name_is_missing(
     assert payload["children"][0]["file"]["name"] == "archive.zip"
 
 
-def test_unnamed_local_file_matches_uploaded_filename(
+@pytest.mark.parametrize(
+    argnames=("local_name", "uploaded_name"),
+    argvalues=[
+        (None, "archive.zip"),
+        ("Download the release", "Download the release"),
+    ],
+)
+def test_local_file_matches_uploaded_name(
     *,
+    local_name: str | None,
+    uploaded_name: str,
     tmp_path: Path,
 ) -> None:
-    """The filename fallback does not trigger another upload."""
+    """Diff sync compares the same display name used for upload."""
     local_file = tmp_path / "archive.zip"
-    local_block = UnoFile(file=ExternalFile(url=local_file.as_uri()))
+    if local_name is None:
+        local_block = UnoFile(file=ExternalFile(url=local_file.as_uri()))
+    else:
+        local_block = UnoFile(
+            file=ExternalFile(url=local_file.as_uri()),
+            name=local_name,
+        )
     existing_block = UnoFile(
         file=NotionFile(
             url="https://example.com/archive.zip",
-            name="archive.zip",
+            name=uploaded_name,
         )
     )
 


### PR DESCRIPTION
Local Notion file uploads now use the source filename when no display name is supplied. Diff synchronization compares the same block display name used during upload, so later builds neither repeat unchanged uploads nor miss custom-name changes. Regression tests cover the append payload, filename fallback, and custom display names. Validated with 256 tests at 100% coverage and all configured lint stages.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 87fc39be752d6c40a5d216fa59d5e522b09b1ab9. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->