### PR TITLE
Publish toctree as a Notion page hierarchy

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -380,6 +380,9 @@ Automatic Publishing Configuration
 
 Instead of using the command-line tool, you can configure automatic publishing to Notion in your ``conf.py``.
 When enabled, documentation will be uploaded to Notion automatically after a successful build with the ``notion`` builder.
+Every document reachable from the root document through a ``toctree`` is published as a child of its corresponding Notion page.
+The root uses ``notion_page_title`` and the other pages use their Sphinx document titles.
+Existing child pages are matched by title and kept in the same hierarchy.
 
 Add the following configuration options to your ``conf.py``:
 

--- a/newsfragments/634.feature.rst
+++ b/newsfragments/634.feature.rst
@@ -1,0 +1,2 @@
+Publish every document reachable through the Sphinx toctree as a matching
+Notion page hierarchy when automatic publishing is enabled.

--- a/src/sphinx_notion/__init__.py
+++ b/src/sphinx_notion/__init__.py
@@ -2,6 +2,7 @@
 
 import datetime as dt
 import json
+from collections import deque
 from collections.abc import Sequence
 from dataclasses import dataclass
 from functools import singledispatch
@@ -2800,6 +2801,16 @@ def _validate_notion_config(
 
 
 @beartype
+def _load_blocks_from_file(*, output_file: Path) -> list[Block]:
+    """Load Notion blocks from a builder output file."""
+    block_dicts = json.loads(s=output_file.read_text(encoding="utf-8"))
+    return [
+        Block.wrap_obj_ref(UnoObjAPIBlock.model_validate(obj=details))
+        for details in block_dicts
+    ]
+
+
+@beartype
 def _publish_to_notion(
     app: Sphinx,
     exception: Exception | None,
@@ -2814,25 +2825,22 @@ def _publish_to_notion(
     if app.builder.name != "notion":
         return
 
-    output_file = Path(app.outdir) / f"{app.config.root_doc}.json"
+    root_doc: str = app.config.root_doc
+    output_file = Path(app.outdir) / f"{root_doc}.json"
     if not output_file.exists():
         _LOGGER.warning(
             "No %s.json found, skipping publish",
-            app.config.root_doc,
+            root_doc,
         )
         return
 
-    block_dicts = json.loads(s=output_file.read_text(encoding="utf-8"))
-    blocks = [
-        Block.wrap_obj_ref(UnoObjAPIBlock.model_validate(obj=details))
-        for details in block_dicts
-    ]
+    toctree_includes: dict[str, list[str]] = app.env.toctree_includes
 
     session = Session(base_url=app.config.notion_api_base_url)
     try:
-        page = upload_to_notion(
+        root_page = upload_to_notion(
             session=session,
-            blocks=blocks,
+            blocks=_load_blocks_from_file(output_file=output_file),
             page_id=app.config.notion_page_id,
             parent_page_id=app.config.notion_parent_page_id,
             parent_database_id=app.config.notion_parent_database_id,
@@ -2844,15 +2852,64 @@ def _publish_to_notion(
             strategy=UploadStrategy(
                 value=app.config.notion_upload_strategy,
             ),
+            allow_subpages=bool(toctree_includes.get(root_doc)),
         )
+        _LOGGER.info(
+            "Published page: '%s' (%s)",
+            app.config.notion_page_title,
+            root_page.url,
+        )
+
+        published_pages = {root_doc: root_page}
+        visited = {root_doc}
+        queue = deque(
+            iterable=(
+                (root_doc, child)
+                for child in toctree_includes.get(root_doc, [])
+            )
+        )
+        while queue:
+            parent_docname, docname = queue.popleft()
+            if docname in visited:
+                continue
+            visited.add(docname)
+
+            doc_output_file = Path(app.outdir) / f"{docname}.json"
+            if not doc_output_file.exists():
+                _LOGGER.warning(
+                    "No %s.json found, skipping publish",
+                    docname,
+                )
+                continue
+
+            parent_page = (
+                root_page
+                if parent_docname == root_doc
+                else published_pages[parent_docname]
+            )
+            title = app.env.titles[docname].astext()
+            child_docnames = toctree_includes.get(docname, [])
+            page = upload_to_notion(
+                session=session,
+                blocks=_load_blocks_from_file(output_file=doc_output_file),
+                page_id=None,
+                parent_page_id=str(object=parent_page.id),
+                parent_database_id=None,
+                title=title,
+                icon=None,
+                cover_path=None,
+                cover_url=None,
+                cancel_on_discussion=app.config.notion_cancel_on_discussion,
+                strategy=UploadStrategy(
+                    value=app.config.notion_upload_strategy,
+                ),
+                allow_subpages=bool(child_docnames),
+            )
+            published_pages[docname] = page
+            queue.extend((docname, child) for child in child_docnames)
+            _LOGGER.info("Published page: '%s' (%s)", title, page.url)
     finally:
         session.close()
-
-    _LOGGER.info(
-        "Published page: '%s' (%s)",
-        app.config.notion_page_title,
-        page.url,
-    )
 
 
 @beartype

--- a/src/sphinx_notion/_upload.py
+++ b/src/sphinx_notion/_upload.py
@@ -20,7 +20,7 @@ from notion_client.errors import HTTPResponseError
 from ultimate_notion import Emoji, ExternalFile, NotionFile, Session
 from ultimate_notion.blocks import PDF as UnoPDF  # noqa: N811
 from ultimate_notion.blocks import Audio as UnoAudio
-from ultimate_notion.blocks import Block, ParentBlock
+from ultimate_notion.blocks import Block, ChildDatabase, ChildPage, ParentBlock
 from ultimate_notion.blocks import File as UnoFile
 from ultimate_notion.blocks import Image as UnoImage
 from ultimate_notion.blocks import Video as UnoVideo
@@ -609,13 +609,13 @@ def _sync_blocks(
     *,
     session: Session,
     page: Page,
+    existing_blocks: Sequence[Block],
     local_blocks: Sequence[Block],
     title: str,
     cancel_on_discussion: bool,
     strategy: UploadStrategy,
 ) -> None:
     """Synchronize local blocks to a page using the selected strategy."""
-    existing_blocks = page.blocks
     plan = (
         _diff_sync_plan(
             existing_blocks=existing_blocks,
@@ -702,6 +702,7 @@ def upload_to_notion(
     cover_url: str | None,
     cancel_on_discussion: bool,
     strategy: UploadStrategy = UploadStrategy.DIFF,
+    allow_subpages: bool = False,
 ) -> Page:
     """Upload documentation to Notion.
 
@@ -761,16 +762,26 @@ def upload_to_notion(
             _LOGGER.info("Creating new page '%s'", title)
             page = session.create_page(parent=parent, title=title)
 
-    if page.subpages:
-        raise PageHasSubpagesError
+    if not allow_subpages:
+        if page.subpages:
+            raise PageHasSubpagesError
 
-    if page.sub_dss:
-        raise PageHasDatabasesError
+        if page.sub_dss:
+            raise PageHasDatabasesError
 
     _LOGGER.info("Syncing page blocks using the '%s' strategy", strategy.value)
     _sync_blocks(
         session=session,
         page=page,
+        existing_blocks=(
+            [
+                block
+                for block in page.blocks
+                if not isinstance(block, (ChildPage, ChildDatabase))
+            ]
+            if allow_subpages
+            else page.blocks
+        ),
         local_blocks=blocks,
         title=title,
         cancel_on_discussion=cancel_on_discussion,

--- a/tests/test_publish.py
+++ b/tests/test_publish.py
@@ -2,6 +2,8 @@
 
 from collections.abc import Callable
 from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
 
 import pytest
 import respx
@@ -166,6 +168,71 @@ def test_publish_success(
         )
         == metadata_clears_before
     )
+
+
+def test_publish_toctree_as_page_hierarchy(
+    *,
+    make_app: Callable[..., SphinxTestApp],
+    tmp_path: Path,
+) -> None:
+    """Each reachable document is published under its parent."""
+    srcdir = tmp_path / "src"
+    srcdir.mkdir()
+    (srcdir / "conf.py").touch()
+    (srcdir / "index.rst").write_text(
+        data="Root\n====\n\n.. toctree::\n\n   guide\n",
+        encoding="utf-8",
+    )
+    (srcdir / "guide.rst").write_text(
+        data="Guide\n=====\n\n.. toctree::\n\n   detail\n",
+        encoding="utf-8",
+    )
+    (srcdir / "detail.rst").write_text(
+        data="Detail\n======\n",
+        encoding="utf-8",
+    )
+    app = make_app(
+        buildername="notion",
+        srcdir=srcdir,
+        confoverrides={
+            "extensions": ["sphinx_notion"],
+            "notion_publish": True,
+            "notion_page_id": "root-page-id",
+            "notion_page_title": "Documentation",
+        },
+    )
+    pages = [
+        SimpleNamespace(id="root-id", url="https://notion.test/root"),
+        SimpleNamespace(id="guide-id", url="https://notion.test/guide"),
+        SimpleNamespace(id="detail-id", url="https://notion.test/detail"),
+    ]
+
+    with (
+        patch(target="sphinx_notion.Session"),
+        patch(
+            target="sphinx_notion.upload_to_notion",
+            side_effect=[*pages, pages[0]],
+        ) as upload,
+    ):
+        app.build()
+        assert app.statuscode == 0
+        assert upload.call_count == len(pages)
+        assert upload.call_args_list[0].kwargs["page_id"] == "root-page-id"
+        assert upload.call_args_list[0].kwargs["allow_subpages"] is True
+        assert upload.call_args_list[1].kwargs["parent_page_id"] == "root-id"
+        assert upload.call_args_list[1].kwargs["title"] == "Guide"
+        assert upload.call_args_list[1].kwargs["allow_subpages"] is True
+        assert upload.call_args_list[2].kwargs["parent_page_id"] == "guide-id"
+        assert upload.call_args_list[2].kwargs["title"] == "Detail"
+        assert upload.call_args_list[2].kwargs["allow_subpages"] is False
+
+        upload.reset_mock()
+        app.env.toctree_includes["index"].append("guide")
+        (Path(app.outdir) / "guide.json").unlink()
+        app.emit("build-finished", None)
+
+        assert upload.call_count == 1
+        assert "No guide.json found" in app.warning.getvalue()
 
 
 def test_publish_replace_strategy(

--- a/tests/test_upload_mock_api.py
+++ b/tests/test_upload_mock_api.py
@@ -450,6 +450,28 @@ def test_upload_page_has_subpages_error(
     )
 
 
+def test_upload_can_preserve_subpages(
+    *,
+    notion_session: Session,
+) -> None:
+    """A hierarchy publish preserves child pages while syncing content."""
+    page = notion_upload.upload_to_notion(
+        session=notion_session,
+        blocks=[],
+        page_id=None,
+        parent_page_id="aaaa0000-0000-0000-0000-000000000001",
+        parent_database_id=None,
+        title="Upload Title",
+        icon=None,
+        cover_path=None,
+        cover_url=None,
+        cancel_on_discussion=False,
+        allow_subpages=True,
+    )
+
+    assert page.title == "Upload Title"
+
+
 def test_upload_page_has_databases_error(
     respx_mock: respx.MockRouter,
     notion_session: Session,


### PR DESCRIPTION
Closes #634.

## What changed

- Publish the root document and every document reachable through its Sphinx toctree.
- Mirror the toctree hierarchy by creating or updating each document beneath its corresponding Notion parent page.
- Preserve child-page and child-database blocks while synchronizing page content.
- Keep the existing root-page configuration, including notion_page_id, appearance settings, cancellation behavior, and upload strategy.
- Document the behavior and add a release note.

## Why

Automatic publishing previously read only the root document JSON, even though the Notion builder writes one JSON file per Sphinx document. Projects with more than one document therefore published only their root page.

## Impact

Existing single-page projects behave as before. Multi-page projects now publish all reachable documents, use each child document Sphinx title, and reuse an existing child page when its title matches under the expected parent.

## Validation

- Full test suite: 259 passed with 100% coverage.
- All pre-commit hooks passed.
- All pre-push type checks passed.
- All manual lint, documentation, spelling, and link checks passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Multi-page projects will publish more Notion pages and API calls than before; upload logic changes how existing child pages interact with block sync, though single-page setups stay on the old path when the root has no toctree children.
> 
> **Overview**
> **Automatic publishing** no longer uploads only the root document’s JSON. After the root page is synced, it walks `app.env.toctree_includes` in breadth-first order and uploads each reachable document’s `{docname}.json` as a **child Notion page** under the parent that matches the toctree (root uses `notion_page_title`; children use Sphinx document titles). Missing JSON files are warned and skipped; duplicate docnames in the walk are ignored.
> 
> **Upload layer** adds `allow_subpages` on `upload_to_notion`. When true, existing **child page** and **child database** blocks are allowed and excluded from content sync so hierarchy pages can keep their subpages while body blocks are updated. `_sync_blocks` now takes `existing_blocks` explicitly instead of always using `page.blocks`.
> 
> Docs and a release note describe the new behavior. Tests cover the hierarchy publish path and subpage preservation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 27d8d1dd4ea5148f620da7f33451a98587962ab7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->