### PR TITLE
Prefer nested parents for duplicate toctree entries

### DIFF
--- a/src/sphinx_notion/__init__.py
+++ b/src/sphinx_notion/__init__.py
@@ -2819,7 +2819,7 @@ def _get_toctree_parent_docnames(
     """Return the preferred parent of every document reachable from root.
 
     Start with a breadth-first tree, then replace a parent only with one of
-    its descendants. This chooses the most deeply nested toctree reference
+    its descendants. This chooses the most deeply nested ``toctree`` reference
     without introducing cycles or choosing between unrelated parents.
     """
     parent_docnames: dict[str, str] = {}

--- a/src/sphinx_notion/__init__.py
+++ b/src/sphinx_notion/__init__.py
@@ -2811,6 +2811,49 @@ def _load_blocks_from_file(*, output_file: Path) -> list[Block]:
 
 
 @beartype
+def _get_toctree_parent_docnames(
+    *,
+    root_doc: str,
+    toctree_includes: dict[str, list[str]],
+) -> dict[str, str]:
+    """Return the preferred parent of every document reachable from root.
+
+    Start with a breadth-first tree, then replace a parent only with one of
+    its descendants. This chooses the most deeply nested toctree reference
+    without introducing cycles or choosing between unrelated parents.
+    """
+    parent_docnames: dict[str, str] = {}
+    reachable_docnames = [root_doc]
+    queue = deque(iterable=[root_doc])
+    while queue:
+        parent_docname = queue.popleft()
+        for docname in toctree_includes.get(parent_docname, []):
+            if docname == root_doc or docname in parent_docnames:
+                continue
+            parent_docnames[docname] = parent_docname
+            reachable_docnames.append(docname)
+            queue.append(docname)
+
+    for parent_docname in reachable_docnames[1:]:
+        for docname in toctree_includes.get(parent_docname, []):
+            if docname == root_doc:
+                continue
+
+            current_parent_docname = parent_docnames[docname]
+            ancestor_docname = parent_docname
+            while ancestor_docname not in {
+                root_doc,
+                current_parent_docname,
+                docname,
+            }:
+                ancestor_docname = parent_docnames[ancestor_docname]
+            if ancestor_docname == current_parent_docname:
+                parent_docnames[docname] = parent_docname
+
+    return parent_docnames
+
+
+@beartype
 def _publish_to_notion(
     app: Sphinx,
     exception: Exception | None,
@@ -2835,6 +2878,13 @@ def _publish_to_notion(
         return
 
     toctree_includes: dict[str, list[str]] = app.env.toctree_includes
+    parent_docnames = _get_toctree_parent_docnames(
+        root_doc=root_doc,
+        toctree_includes=toctree_includes,
+    )
+    child_docnames_by_parent: dict[str, list[str]] = {}
+    for docname, parent_docname in parent_docnames.items():
+        child_docnames_by_parent.setdefault(parent_docname, []).append(docname)
 
     session = Session(base_url=app.config.notion_api_base_url)
     try:
@@ -2852,7 +2902,7 @@ def _publish_to_notion(
             strategy=UploadStrategy(
                 value=app.config.notion_upload_strategy,
             ),
-            allow_subpages=bool(toctree_includes.get(root_doc)),
+            allow_subpages=bool(child_docnames_by_parent.get(root_doc)),
         )
         _LOGGER.info(
             "Published page: '%s' (%s)",
@@ -2861,18 +2911,14 @@ def _publish_to_notion(
         )
 
         published_pages = {root_doc: root_page}
-        visited = {root_doc}
         queue = deque(
             iterable=(
                 (root_doc, child)
-                for child in toctree_includes.get(root_doc, [])
+                for child in child_docnames_by_parent.get(root_doc, [])
             )
         )
         while queue:
             parent_docname, docname = queue.popleft()
-            if docname in visited:
-                continue
-            visited.add(docname)
 
             doc_output_file = Path(app.outdir) / f"{docname}.json"
             if not doc_output_file.exists():
@@ -2888,7 +2934,7 @@ def _publish_to_notion(
                 else published_pages[parent_docname]
             )
             title = app.env.titles[docname].astext()
-            child_docnames = toctree_includes.get(docname, [])
+            child_docnames = child_docnames_by_parent.get(docname, [])
             page = upload_to_notion(
                 session=session,
                 blocks=_load_blocks_from_file(output_file=doc_output_file),

--- a/tests/test_publish.py
+++ b/tests/test_publish.py
@@ -180,7 +180,7 @@ def test_publish_toctree_as_page_hierarchy(
     srcdir.mkdir()
     (srcdir / "conf.py").touch()
     (srcdir / "index.rst").write_text(
-        data="Root\n====\n\n.. toctree::\n\n   guide\n",
+        data="Root\n====\n\n.. toctree::\n\n   detail\n   guide\n",
         encoding="utf-8",
     )
     (srcdir / "guide.rst").write_text(
@@ -211,7 +211,13 @@ def test_publish_toctree_as_page_hierarchy(
         patch(target="sphinx_notion.Session"),
         patch(
             target="sphinx_notion.upload_to_notion",
-            side_effect=[*pages, pages[0]],
+            side_effect=[
+                *pages,
+                pages[0],
+                pages[2],
+                pages[1],
+                pages[0],
+            ],
         ) as upload,
     ):
         app.build()
@@ -227,6 +233,17 @@ def test_publish_toctree_as_page_hierarchy(
         assert upload.call_args_list[2].kwargs["allow_subpages"] is False
 
         upload.reset_mock()
+        app.env.toctree_includes["detail"] = ["guide", "index"]
+        app.emit("build-finished", None)
+
+        assert upload.call_count == len(pages)
+        assert upload.call_args_list[1].kwargs["parent_page_id"] == "root-id"
+        assert upload.call_args_list[1].kwargs["title"] == "Detail"
+        assert upload.call_args_list[2].kwargs["parent_page_id"] == "detail-id"
+        assert upload.call_args_list[2].kwargs["title"] == "Guide"
+
+        upload.reset_mock()
+        app.env.toctree_includes["detail"] = []
         app.env.toctree_includes["index"].append("guide")
         (Path(app.outdir) / "guide.json").unlink()
         app.emit("build-finished", None)


### PR DESCRIPTION
Resolve duplicate toctree references to the deepest valid parent so root-level glob or hidden entries do not flatten the Notion hierarchy. Build the publishing queue from that resolved hierarchy while preventing cycles and arbitrary reparenting between unrelated sections. Extend the publishing behavior test to cover duplicate and cyclic references without testing private helpers. Validation: 259 tests pass with 100% coverage, and all pre-commit and pre-push checks pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how the Notion publish walk derives parent/child pages from Sphinx toctrees; wrong resolution would mis-nest or skip pages, though behavior is covered by extended publish tests.
> 
> **Overview**
> When the same Sphinx document appears in more than one `toctree`, publishing now picks a **single parent** per page—the deepest valid nested reference—instead of treating raw `toctree_includes` as the tree. That stops root-level glob or hidden entries from flattening the Notion subpage layout.
> 
> A new `_get_toctree_parent_docnames` builds a BFS tree from the root, then reparents only when the new parent is a descendant of the current one, avoiding cycles and arbitrary jumps between unrelated sections. `_publish_to_notion` walks **`child_docnames_by_parent`** from that map (including `allow_subpages`), and drops the old publish-queue `visited` guard because duplicates are resolved upstream.
> 
> Tests add `detail` at the root alongside `guide → detail`, and re-emit `build-finished` with cyclic `toctree_includes` to assert **Detail** stays under root and **Guide** under **detail**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f96a71d74f144e9a8f30b74068fd7b2fb9cd902e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->