### PR TITLE
Add no-defaults linting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -429,7 +429,7 @@ repos:
         stages: [pre-commit]
 
   - repo: https://github.com/adamtheturtle/no-defaults
-    rev: v1.0.0
+    rev: v1.0.1
     hooks:
       - id: no-defaults
         stages: [pre-commit]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -270,6 +270,16 @@ repos:
         stages: [pre-commit]
         require_serial: true
 
+      - id: no-defaults
+        name: no-defaults
+        entry: uv run --extra=dev no-defaults
+        language: python
+        types_or: [python]
+        additional_dependencies:
+          - *uv_version
+        stages: [pre-commit]
+        require_serial: true
+
       - id: doc8
         name: doc8
         entry: uv run --extra=dev -m doc8
@@ -426,10 +436,4 @@ repos:
         types_or: [rst]
         additional_dependencies:
           - *uv_version
-        stages: [pre-commit]
-
-  - repo: https://github.com/adamtheturtle/no-defaults
-    rev: v1.0.1
-    hooks:
-      - id: no-defaults
         stages: [pre-commit]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -427,3 +427,9 @@ repos:
         additional_dependencies:
           - *uv_version
         stages: [pre-commit]
+
+  - repo: https://github.com/adamtheturtle/no-defaults
+    rev: v1.0.0
+    hooks:
+      - id: no-defaults
+        stages: [pre-commit]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -178,6 +178,7 @@ lint.unfixable = [
 # external code lets us use ``# noqa: KW001`` without Ruff reporting RUF102.
 lint.external = [
     "KW001",
+    "NOD",
 ]
 lint.flake8-tidy-imports.banned-api."typing.cast".msg = "typing.cast is banned: use explicit type narrowing or a typed variable instead."
 lint.pydocstyle.convention = "google"
@@ -532,3 +533,7 @@ ignore_path = [
 [tool.yamlfix]
 section_whitelines = 1
 whitelines = 1
+
+[tool.no_defaults]
+private_only = true
+per_file_enforcement."tests/**" = "all"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,7 @@ optional-dependencies.dev = [
     "interrogate==1.7.0",
     "mypy[faster-cache]==2.3.0",
     "mypy-strict-kwargs==2026.7.19.1",
+    "no-defaults==1.0.1",
     "prek==0.4.11",
     "pydocstringformatter==1.0.0",
     "pydocstyle==6.3",

--- a/src/sphinx_notion/__init__.py
+++ b/src/sphinx_notion/__init__.py
@@ -1560,7 +1560,7 @@ def _(
 def _create_rich_text_from_line_block(
     *,
     node: nodes.line_block,
-    indentation_level: int = 0,
+    indentation_level: int = 0,  # noqa: NOD001
 ) -> Text:
     """Flatten a nested line block with deterministic indentation."""
     rich_text = Text.from_plain_text(text="")

--- a/src/sphinx_notion/_upload.py
+++ b/src/sphinx_notion/_upload.py
@@ -701,8 +701,8 @@ def upload_to_notion(
     cover_path: Path | None,
     cover_url: str | None,
     cancel_on_discussion: bool,
-    strategy: UploadStrategy = UploadStrategy.DIFF,
-    allow_subpages: bool = False,
+    strategy: UploadStrategy = UploadStrategy.DIFF,  # noqa: NOD001
+    allow_subpages: bool = False,  # noqa: NOD001
 ) -> Page:
     """Upload documentation to Notion.
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -92,10 +92,10 @@ def _assert_rst_converts_to_notion_objects(
     expected_blocks: Sequence[Block],
     make_app: Callable[..., SphinxTestApp],
     tmp_path: Path,
-    extensions: tuple[str, ...] = ("sphinx_notion",),
-    conf_py_content: str = "",
+    extensions: tuple[str, ...] = ("sphinx_notion",),  # noqa: NOD001
+    conf_py_content: str = "",  # noqa: NOD001
     expected_warnings: Collection[str],
-    confoverrides: dict[str, Any] | None = None,
+    confoverrides: dict[str, Any] | None = None,  # noqa: NOD001
 ) -> SphinxTestApp:
     """
     ReStructuredText content converts to expected Notion objects via

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -39,9 +39,9 @@ def _invoke_upload(
     blocks_file: Path,
     parent_page_id: str | None,
     mock_api_base_url: str,
-    cancel_on_discussion: bool = False,
-    page_id: str | None = None,
-    strategy: str | None = None,
+    cancel_on_discussion: bool = False,  # noqa: NOD001
+    page_id: str | None = None,  # noqa: NOD001
+    strategy: str | None = None,  # noqa: NOD001
 ) -> Result:
     """Invoke the upload CLI against the mock Notion API."""
     runner = CliRunner()


### PR DESCRIPTION
Add `no-defaults` v1.0.0 to the pre-commit/prek configuration.

The policy rejects defaults everywhere in `tests/**` and for private functions, classes, and modules elsewhere. Existing defaults are behavior-preservingly baselined with targeted `# noqa: NOD001` comments where necessary; Ruff is configured to recognize the external `NOD` rule family. Vendored Typeshed is excluded where applicable.

Validated with `prek validate-config`, `prek run no-defaults --all-files`, and Ruff checks.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Tooling and noqa baselines only; runtime upload and Sphinx conversion logic are unchanged.
> 
> **Overview**
> Adds the **no-defaults** linter (`1.0.1`) to dev dependencies and a **pre-commit** hook that runs `uv run no-defaults` on Python files.
> 
> **Policy** in `pyproject.toml`: `private_only = true` elsewhere, and `tests/**` enforces **all** parameters (no defaults). Ruff’s `lint.external` now includes **`NOD`** so `# noqa: NOD001` baselines are accepted.
> 
> Existing defaults are kept with targeted **`# noqa: NOD001`** on one private helper in `__init__.py`, `upload_to_notion` in `_upload.py`, and test helpers in `test_integration.py` / `test_upload.py`—no behavior changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 53e23c1cc7a46575bed9a8027797483daa2d1103. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->