### PR TITLE
Collapse the per-parameter suppressions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ optional-dependencies.dev = [
     "interrogate==1.7.0",
     "mypy[faster-cache]==2.3.0",
     "mypy-strict-kwargs==2026.7.19.1",
-    "no-defaults==1.0.1",
+    "no-defaults==1.1.0",
     "prek==0.4.11",
     "pydocstringformatter==1.0.0",
     "pydocstyle==6.3",

--- a/src/sphinx_notion/_upload.py
+++ b/src/sphinx_notion/_upload.py
@@ -689,7 +689,7 @@ def _set_page_appearance(
 
 
 @beartype
-def upload_to_notion(
+def upload_to_notion(  # noqa: NOD001
     *,
     session: Session,
     blocks: Sequence[Block],
@@ -701,8 +701,8 @@ def upload_to_notion(
     cover_path: Path | None,
     cover_url: str | None,
     cancel_on_discussion: bool,
-    strategy: UploadStrategy = UploadStrategy.DIFF,  # noqa: NOD001
-    allow_subpages: bool = False,  # noqa: NOD001
+    strategy: UploadStrategy = UploadStrategy.DIFF,
+    allow_subpages: bool = False,
 ) -> Page:
     """Upload documentation to Notion.
 


### PR DESCRIPTION
Bumps `no-defaults` to 1.1.0 and collapses the per-parameter `NOD001` directives.

Since 1.1.0 a directive on the `def` line covers every parameter of that signature, so a wide signature needs one directive rather than one per parameter.

**3 → 2.** `upload_to_notion` drops from 2 directives to 1.

The defaults themselves are unchanged — these are public API signatures, where removing a default is a breaking change for callers. This is purely about how the suppressions are written. Comment-only apart from the version pin; ruff clean and the test suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment and dev-dependency pin only; no runtime or API behavior changes.
> 
> **Overview**
> **Dev dependency:** `no-defaults` is pinned from **1.0.1** to **1.1.0**, which allows a `# noqa: NOD001` on the `def` line to cover every parameter in that signature.
> 
> **Lint-only refactor in** `upload_to_notion`: one `# noqa: NOD001` on the function definition replaces separate directives on `strategy` and `allow_subpages`. **Default argument values are unchanged** (still public API).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 81b63fbe3ef29499112a21de72d90ea24e458384. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->