### PR TITLE
Bump beartype to 0.23.0rc0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dynamic = [
 ]
 dependencies = [
     "atsphinx-audioplayer>=0.2.1",
-    "beartype>=0.21.0",
+    "beartype==0.23.0rc0",
     "beautifulsoup4>=4.13.3",
     "click>=8.0.0",
     "cloup>=3.0.0",


### PR DESCRIPTION
Tests the [beartype 0.23.0rc0](https://pypi.org/project/beartype/0.23.0rc0/) release candidate against this repository's test suite.

Pins `beartype` to the release candidate in `pyproject.toml` and updates `uv.lock` to match.

Not intended to merge as-is — the pin should be relaxed once the release candidate has been evaluated.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only dependency resolution changes in packaging metadata; no runtime or extension code is modified, though the RC pin could surface new beartype behavior in tests.
> 
> **Overview**
> **Pins `beartype` to the 0.23.0 release candidate** so CI and local installs resolve exactly that version instead of any `>=0.21.0` release.
> 
> This is a **temporary evaluation change**: the PR description says the suite is being run against the RC and the strict pin should be relaxed after the candidate is vetted, not merged as a permanent `==` pin.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 734c5dca2e2f34800b8d2d4a311f54af2c1a99bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->